### PR TITLE
Don't run FindBugs on generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@ Gradle Processors
 =================
 
 A plugin for Gradle that cleans up integration of Java 6+ [annotation processors][] with the
-[Eclipse][] and [IDEA][] plugins.
+[Eclipse][], [IDEA][] and [FindBugs][] plugins.
 
 [annotation processors]: http://docs.oracle.com/javase/6/docs/api/javax/annotation/processing/Processor.html
 [Eclipse]: https://docs.gradle.org/current/userguide/eclipse_plugin.html
 [IDEA]: https://docs.gradle.org/current/userguide/idea_plugin.html
+[FindBugs]: https://docs.gradle.org/current/userguide/findbugs_plugin.html
 
 Quickstart
 ----------

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use it, add the following to your top-level build.gradle file:
 ```gradle
 
 plugins {
-  id 'org.inferred.processors' version '1.0.1'
+  id 'org.inferred.processors' version '1.0.2'
 }
 ```
 
@@ -57,7 +57,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'gradle.plugin.org.inferred:gradle-processors:1.0.1'
+    classpath 'gradle.plugin.org.inferred:gradle-processors:1.0.2'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 }
 
 group = 'org.inferred'
-version = '1.0.1'
+version = '1.0.2'
 
 pluginBundle {
   website = 'https://github.com/palantir/gradle-processors'

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -9,6 +9,7 @@ import org.gradle.api.NamedDomainObjectCollection
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.quality.FindBugs
 import org.gradle.api.specs.Spec
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
@@ -133,6 +134,23 @@ class ProcessorsPlugin implements Plugin<Project> {
       }
 
     })
+
+    /**** FindBugs ********************************************************************************/
+    project.tasks.withType(FindBugs, { task -> task.doFirst {
+      // Exclude generated sources from FindBugs' traversal.
+      // This trick relies on javac putting the generated .java files next to the .class files.
+      def generatedSources = task.classes.filter {
+        it.path.endsWith '.java'
+      }
+      task.classes = task.classes.filter {
+        File javaFile = new File(it.path
+            .replaceFirst(/\$\w+\.class$/, '')
+            .replaceFirst(/\.class$/, '')
+            + '.java')
+        boolean isGenerated = generatedSources.contains(javaFile)
+        return !isGenerated
+      }
+    }})
   }
 
   /** Runs {@code action} on element {@code name} in {@code collection} whenever it is added. */

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -119,6 +119,33 @@ public class ProcessorsPluginFunctionalTest {
         .build()
   }
 
+  @Test
+  public void testFindBugsIntegration() throws IOException {
+    buildFile << """
+      apply plugin: 'java'
+      apply plugin: 'findbugs'
+      apply plugin: 'org.inferred.processors'
+
+      dependencies {
+        processor 'org.immutables:value:2.0.21'
+      }
+    """
+
+    new File(testProjectDir.newFolder('src', 'main', 'java'), 'MyClass.java') << """
+      import org.immutables.value.Value;
+
+      @Value.Immutable
+      public interface MyClass {
+        @Value.Parameter String getValue();
+      }
+    """
+
+    GradleRunner.create()
+        .withProjectDir(testProjectDir.getRoot())
+        .withArguments("findbugsMain")
+        .build()
+  }
+
   private void writeBuildscript() {
     def pluginClasspathResource = getClass().classLoader.findResource("plugin-classpath.txt")
     if (pluginClasspathResource == null) {


### PR DESCRIPTION
This trick relies on javac putting the generated .java files next to the .class files. Ugly, but it seems to work, and nothing cleaner seems to be an option at the moment.

This fixes #6.