### PR TITLE
Avoid adding processors to compile configuration

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -30,10 +30,8 @@ class ProcessorsPlugin implements Plugin<Project> {
     }
 
     /**** javac, groovy, etc. *********************************************************************/
-    withName(project.configurations, 'compile', { c ->
-      c.extendsFrom(project.configurations.getAt('processor'))
-    })
     project.plugins.withType(JavaPlugin, { plugin ->
+      project.sourceSets.each { it.compileClasspath += [project.configurations.processor] }
       project.compileJava.dependsOn project.task('processorPath', {
         doLast {
           def config = project.configurations.getAt('processor').resolvedConfiguration


### PR DESCRIPTION
Fixes #3.

Usually, annotation processors are only required at compile
time, not runtime. This change makes it so that they're made
available at compile time, but not listed in published ivy.xml
and pom.xml files.