### PR TITLE
Avoid adding processors to compile configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use it, add the following to your top-level build.gradle file:
 ```gradle
 
 plugins {
-  id 'org.inferred.processors' version '1.0.2'
+  id 'org.inferred.processors' version '1.1'
 }
 ```
 
@@ -58,7 +58,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'gradle.plugin.org.inferred:gradle-processors:1.0.2'
+    classpath 'gradle.plugin.org.inferred:gradle-processors:1.1'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 }
 
 group = 'org.inferred'
-version = '1.0.2'
+version = '1.1'
 
 pluginBundle {
   website = 'https://github.com/palantir/gradle-processors'

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -30,10 +30,8 @@ class ProcessorsPlugin implements Plugin<Project> {
     }
 
     /**** javac, groovy, etc. *********************************************************************/
-    withName(project.configurations, 'compile', { c ->
-      c.extendsFrom(project.configurations.getAt('processor'))
-    })
     project.plugins.withType(JavaPlugin, { plugin ->
+      project.sourceSets.each { it.compileClasspath += [project.configurations.processor] }
       project.compileJava.dependsOn project.task('processorPath', {
         doLast {
           def config = project.configurations.getAt('processor').resolvedConfiguration


### PR DESCRIPTION
This fixes #3. Processors which need to be made available downstream will now have to be added with `compile` in addition to `processor`.

Thanks to @punya for providing the core of this PR!