### PR TITLE
Build with support for running under Java7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 }
 
 group = 'org.inferred'
-version = '1.1'
+version = '1.1.2'
 
 pluginBundle {
   website = 'https://github.com/palantir/gradle-processors'

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,12 @@ pluginBundle {
   }
 }
 
+// Ensure Java7 compatibility
+tasks.withType(GroovyCompile) {
+    sourceCompatibility = '1.7'
+    targetCompatibility = '1.7'
+}
+
 // Write the plugin's classpath to a file to share with the tests
 task createClasspathManifest {
   def outputDir = file("$buildDir/$name")


### PR DESCRIPTION
Change the source and target compatibility to 1.7 so that the plugin can run under JDK 1.7.

See: #17