### PR TITLE
Remove runtime deps from provided scope in intellij

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -87,6 +87,7 @@ class ProcessorsPlugin implements Plugin<Project> {
     project.plugins.withType(IdeaPlugin, { plugin ->
       if (project.idea.module.scopes.PROVIDED != null) {
         project.idea.module.scopes.PROVIDED.plus += [project.configurations.processor]
+        project.idea.module.scopes.PROVIDED.minus += [project.configurations.runtime]
       }
 
       /*


### PR DESCRIPTION
This addresses issue #4
(https://github.com/palantir/gradle-processors/issues/4)
which previously caused transitive dependencies of annotation processors
to be removed from the compile and runtime scopes even if they were
separately added.

Concretely, this allows using gradle-processors with the immutables-gson
and immutables-mongo annotation processors, both of which have required
runtime dependencies.