### PR TITLE
Remove unnecessary requirement to import 'idea' plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use it, add the following to your top-level build.gradle file:
 ```gradle
 
 plugins {
-  id 'org.inferred.processors' version '1.2'
+  id 'org.inferred.processors' version '1.2.1'
 }
 ```
 
@@ -59,7 +59,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'gradle.plugin.org.inferred:gradle-processors:1.2'
+    classpath 'gradle.plugin.org.inferred:gradle-processors:1.2.1'
   }
 }
 

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -104,19 +104,19 @@ class ProcessorsPlugin implements Plugin<Project> {
           }
         }
       }
-
-      // If the project uses .idea directory structure, update compiler.xml directly
-      File ideaCompilerXml = project.file('.idea/compiler.xml')
-      if (ideaCompilerXml.isFile()) {
-        Node parsedProjectXml = (new XmlParser()).parse(ideaCompilerXml)
-        updateIdeaCompilerConfiguration(project, parsedProjectXml)
-        ideaCompilerXml.withWriter { writer ->
-          XmlNodePrinter nodePrinter = new XmlNodePrinter(new PrintWriter(writer))
-          nodePrinter.setPreserveWhitespace(true)
-          nodePrinter.print(parsedProjectXml)
-        }
-      }
     })
+
+    // If the project uses .idea directory structure, update compiler.xml directly
+    File ideaCompilerXml = project.file('.idea/compiler.xml')
+    if (ideaCompilerXml.isFile()) {
+      Node parsedProjectXml = (new XmlParser()).parse(ideaCompilerXml)
+      updateIdeaCompilerConfiguration(project, parsedProjectXml)
+      ideaCompilerXml.withWriter { writer ->
+        XmlNodePrinter nodePrinter = new XmlNodePrinter(new PrintWriter(writer))
+        nodePrinter.setPreserveWhitespace(true)
+        nodePrinter.print(parsedProjectXml)
+      }
+    }
 
     /**** FindBugs ********************************************************************************/
     project.tasks.withType(FindBugs, { task -> task.doFirst {


### PR DESCRIPTION
Now you can open build.gradle files directly from IntelliJ, without needing to import the 'idea' plugin as well. Note that you still need to configure the 'Annotation Processors' pane in the project config (issue #29).

This fixes #28.