### PR TITLE
remove the need to apply plugin to the root project

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,7 @@ A plugin for Gradle that cleans up integration of Java 6+ [annotation processors
 Quickstart
 ----------
 
-To use it, add the following to your top-level build.gradle file:
-
-```gradle
-
-plugins {
-  id 'org.inferred.processors' version '1.2.1'
-}
-```
-
-And the same without the version number in your subproject build.gradle files:
+To use it, add the following to your project's build.gradle file:
 
 ```gradle
 
@@ -62,11 +53,9 @@ buildscript {
     classpath 'gradle.plugin.org.inferred:gradle-processors:1.2.1'
   }
 }
-
-apply plugin: 'org.inferred.processors'
 ```
 
-And add just the apply directive to your subproject build.gradle files:
+And just the apply directive to your subproject build.gradle files:
 
 ```gradle
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A plugin for Gradle that cleans up integration of Java 6+ [annotation processors
 Quickstart
 ----------
 
-To use it, add the following to your project's build.gradle file:
+To use it, add the following to your projects' build.gradle file:
 
 ```gradle
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use it, add the following to your project's build.gradle file:
 ```gradle
 
 plugins {
-  id 'org.inferred.processors'
+  id 'org.inferred.processors' version '1.2.1'
 }
 ```
 

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -90,8 +90,8 @@ class ProcessorsPlugin implements Plugin<Project> {
       addGeneratedSourceFolder(project, project.processors.testSourceOutputDir, true)
 
       // Root project configuration
-      if (project.idea.project != null) {
-        project.idea.project.ipr {
+      if (project.rootProject.idea.project != null) {
+        project.rootProject.idea.project.ipr {
           withXml {
             updateIdeaCompilerConfiguration(project, node)
           }


### PR DESCRIPTION
this change makes it so you only need to apply the plugin to the sub-projects and not the root project.

a common snag was users would apply this ONLY to the sub-project, and would wonder why things didn't work. this change should hopefully get rid of that...