### PR TITLE
Fix issues with Eclipse/IDEA tasks

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -65,7 +65,7 @@ class ProcessorsPlugin implements Plugin<Project> {
               'org/inferred/gradle/apt-prefs.template',
               '.settings/org.eclipse.jdt.apt.core.prefs',
               [
-                sourceOutputDir: project.processors.sourceOutputDir,
+                config: project.processors,
                 deps: project.configurations.processor
               ]
           )
@@ -161,7 +161,7 @@ class ProcessorsPlugin implements Plugin<Project> {
     def outputFile = new File(project.projectDir, outputFilename)
     def cleanTaskName = "clean" + taskName.substring(0, 1).toUpperCase() + taskName.substring(1)
     project.task(taskName, {
-      binding.each{ k, v -> inputs.property k, v }
+      inputs.property 'deps', binding.deps
       outputs.file outputFile
       doLast {
         outputFile.parentFile.mkdirs()

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -11,6 +11,7 @@ import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.quality.FindBugs
 import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Delete
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
 
@@ -182,11 +183,9 @@ class ProcessorsPlugin implements Plugin<Project> {
       }
     })
 
-    project.task(cleanTaskName, {
-      doLast {
-        outputFile.delete()
-      }
-    })
+    project.task(cleanTaskName, type: Delete) {
+      delete outputFile
+    }
   }
 
   static void updateIdeaCompilerConfiguration(Project project, Node projectConfiguration) {

--- a/src/main/resources/org/inferred/gradle/apt-prefs.template
+++ b/src/main/resources/org/inferred/gradle/apt-prefs.template
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 <% if (!deps.empty) { %>\
 org.eclipse.jdt.apt.aptEnabled=true
-org.eclipse.jdt.apt.genSrcDir=${sourceOutputDir}
+org.eclipse.jdt.apt.genSrcDir=${config.sourceOutputDir}
 org.eclipse.jdt.apt.reconcileEnabled=true
 <% } else { %>\
 org.eclipse.jdt.apt.aptEnabled=false

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -10,6 +10,7 @@ import org.junit.rules.TemporaryFolder
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
 
 public class ProcessorsPluginFunctionalTest {
 
@@ -283,6 +284,34 @@ public class ProcessorsPluginFunctionalTest {
       org.eclipse.jdt.apt.reconcileEnabled=true
     """.replaceFirst('\n','').stripIndent()
     assertEquals(expected, prefsFile.text)
+  }
+
+  @Test
+  public void testCleanEclipseAptPrefs() throws IOException {
+    buildFile << """
+      apply plugin: 'java'
+      apply plugin: 'eclipse'
+      apply plugin: 'org.inferred.processors'
+
+      dependencies {
+        processor 'org.immutables:value:2.0.21'
+      }
+    """
+
+    File testProjectDirRoot = testProjectDir.getRoot()
+
+    GradleRunner.create()
+            .withProjectDir(testProjectDirRoot)
+            .withArguments("eclipseAptPrefs")
+            .build()
+    GradleRunner.create()
+            .withProjectDir(testProjectDirRoot)
+            .withArguments("cleanEclipseAptPrefs")
+            .build()
+
+    def prefsFile = new File(testProjectDirRoot, ".settings/org.eclipse.jdt.apt.core.prefs")
+
+    assertFalse(prefsFile.exists())
   }
 
   @Test


### PR DESCRIPTION
 * Fix Eclipse/IDEA tasks to respect changes to `processors.sourceOutputDir`.
 * Use Delete for cleanX tasks so UP-TO-DATE checks are done correctly.