### PR TITLE
Default Eclipse to bin/generated/java

### DIFF
--- a/src/main/resources/org/inferred/gradle/apt-prefs.template
+++ b/src/main/resources/org/inferred/gradle/apt-prefs.template
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 <% if (!deps.empty) { %>\
 org.eclipse.jdt.apt.aptEnabled=true
-org.eclipse.jdt.apt.genSrcDir=${config.sourceOutputDir}
+org.eclipse.jdt.apt.genSrcDir=${sourceOutputDir}
 org.eclipse.jdt.apt.reconcileEnabled=true
 <% } else { %>\
 org.eclipse.jdt.apt.aptEnabled=false

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
@@ -26,9 +26,11 @@ class ProcessorsPluginTest {
   public void addsSourceDirectoryConfiguration() {
     Project project = ProjectBuilder.builder().build()
     project.pluginManager.apply 'org.inferred.processors'
+    project.pluginManager.apply 'idea'
+    project.pluginManager.apply 'java'
 
-    assertEquals 'generated_src', project.processors.sourceOutputDir
-    assertEquals 'generated_testSrc', project.processors.testSourceOutputDir
+    assertEquals 'generated_src', project.idea.processors.sourceOutputDir
+    assertEquals 'generated_testSrc', project.idea.processors.testSourceOutputDir
   }
 
   @Test


### PR DESCRIPTION
Writing to the output directory ensures generated code is clearly distinguished from source code, and can be deleted all at once. This requires splitting the Eclipse and IDEA configuration extensions, which are now under `eclipse.processors` and `idea.processors`, respectively.