### PR TITLE
Respect TRAVIS_TAG above gitVersion()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,14 +11,38 @@ repositories {
   mavenCentral()
 }
 
+sourceCompatibility = '1.7'
+
 dependencies {
   compile localGroovy()
   compile 'org.codehaus.groovy:groovy-backports-compat23:2.3.5'
   testCompile gradleTestKit()
 }
 
+//// Tests ////////////////////////////////////////////////////////////////////////////
+
+// Write the plugin's classpath to a file to share with the tests
+task createClasspathManifest {
+  def outputDir = file("$buildDir/$name")
+
+  inputs.files sourceSets.main.runtimeClasspath
+  outputs.dir outputDir
+
+  doLast {
+    outputDir.mkdirs()
+    file("$outputDir/plugin-classpath.txt").text = sourceSets.main.runtimeClasspath.join("\n")
+  }
+}
+
+// Add the classpath file to the test runtime classpath
+dependencies {
+  testRuntime files(createClasspathManifest)
+}
+
+//// Publication //////////////////////////////////////////////////////////////////////
+
 group = 'org.inferred'
-version = gitVersion().replaceAll('^v', '')
+version = (System.env.TRAVIS_TAG ?: gitVersion()).replaceAll('^v','')
 
 pluginBundle {
   website = 'https://github.com/palantir/gradle-processors'
@@ -46,27 +70,3 @@ task setupPublishProperties << {
   }
 }
 tasks.publishPlugins.dependsOn tasks.setupPublishProperties
-
-// Ensure Java7 compatibility
-tasks.withType(GroovyCompile) {
-    sourceCompatibility = '1.7'
-    targetCompatibility = '1.7'
-}
-
-// Write the plugin's classpath to a file to share with the tests
-task createClasspathManifest {
-  def outputDir = file("$buildDir/$name")
-
-  inputs.files sourceSets.main.runtimeClasspath
-  outputs.dir outputDir
-
-  doLast {
-    outputDir.mkdirs()
-    file("$outputDir/plugin-classpath.txt").text = sourceSets.main.runtimeClasspath.join("\n")
-  }
-}
-
-// Add the classpath file to the test runtime classpath
-dependencies {
-  testRuntime files(createClasspathManifest)
-}


### PR DESCRIPTION
Rereleasing an existing tag with a new version (e.g. promoting a release candidate) requires the build respecting `$TRAVIS_TAG` rather than trying to guess the correct version from the git repository.
