### PR TITLE
remove immutables findbug code

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -122,23 +122,6 @@ class ProcessorsPlugin implements Plugin<Project> {
         nodePrinter.print(parsedProjectXml)
       }
     }
-
-    /**** FindBugs ********************************************************************************/
-    project.tasks.withType(FindBugs, { task -> task.doFirst {
-      // Exclude generated sources from FindBugs' traversal.
-      // This trick relies on javac putting the generated .java files next to the .class files.
-      def generatedSources = task.classes.filter {
-        it.path.endsWith '.java'
-      }
-      task.classes = task.classes.filter {
-        File javaFile = new File(it.path
-            .replaceFirst(/\$\w+\.class$/, '')
-            .replaceFirst(/\.class$/, '')
-            + '.java')
-        boolean isGenerated = generatedSources.contains(javaFile)
-        return !isGenerated
-      }
-    }})
   }
 
   /** Runs {@code action} on element {@code name} in {@code collection} whenever it is added. */
@@ -255,3 +238,4 @@ class IdeaProcessorsExtension {
   Object outputDir
   Object testOutputDir
 }
+


### PR DESCRIPTION
@chrisalice 

Some product builds started failing findbugs because not all Immutable classes were successfully ignored. Removing this block of code and upgrading to a new Immutables version for these products seems to be a valid workaround.