### PR TITLE
Fix bugs in support for directory-based idea projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,12 @@ dependencies {
   testRuntime files(createClasspathManifest)
 }
 
+test {
+  testLogging {
+    exceptionFormat = 'full'
+  }
+}
+
 //// Publication //////////////////////////////////////////////////////////////////////
 
 group = 'org.inferred'

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -595,10 +595,9 @@ public class ProcessorsPluginFunctionalTest {
             .withArguments("idea", "--stacktrace")
             .build()
 
-    def xml = new XmlSlurper().parse(testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile())
+    def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
 
-    def expected = new XmlSlurper().parseText("""
-      <?xml version="1.0" encoding="UTF-8"?>
+    def expected = """
       <project version="4">
         <component name="CompilerConfiguration">
           <annotationProcessing>
@@ -611,7 +610,7 @@ public class ProcessorsPluginFunctionalTest {
           </annotationProcessing>
         </component>
       </project>
-    """.trim())
+    """.stripIndent().trim()
 
     assertEquals(expected, xml)
   }
@@ -638,10 +637,9 @@ public class ProcessorsPluginFunctionalTest {
             .withArguments("idea", "--stacktrace")
             .build()
 
-    def xml = new XmlSlurper().parse(testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile())
+    def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
 
-    def expected = new XmlSlurper().parseText("""
-      <?xml version="1.0" encoding="UTF-8"?>
+    def expected = """
       <project version="4">
         <component name="CompilerConfiguration">
           <annotationProcessing>
@@ -654,7 +652,7 @@ public class ProcessorsPluginFunctionalTest {
           </annotationProcessing>
         </component>
       </project>
-    """.trim())
+    """.stripIndent().trim()
 
     assertEquals(expected, xml)
   }


### PR DESCRIPTION
Two issues have arisen in our support for directory based idea projects:

 * We regressed on issue #28, once again requiring the user import the 'idea' plugin
 * Issue #53: correctness depends on plugin ordering

This PR fixes both by only updating compiler.xml after the project is evaluated, and using default values for sourceOutputDir/sourceTestOutputDir if the IDEA plugin has not been applied.\

It also fixes our existing compiler.xml tests, which were erroneously using `assertEquals` on the lazy objects returned by XMLSlurper.

This PR fixes #53.