### PR TITLE
Default Eclipse to write to generated/java, not bin/generated/java

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -45,7 +45,7 @@ class ProcessorsPlugin implements Plugin<Project> {
           project.eclipse {
             extensions.create('processors', EclipseProcessorsExtension)
             processors.conventionMapping.outputDir = {
-              new File(project.eclipse.classpath.defaultOutputDir, 'generated/java')
+              project.file('generated/java')
             }
 
             classpath.plusConfigurations += [project.configurations.processor]

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -276,48 +276,7 @@ public class ProcessorsPluginFunctionalTest {
     def expected = """
       eclipse.preferences.version=1
       org.eclipse.jdt.apt.aptEnabled=true
-      org.eclipse.jdt.apt.genSrcDir=bin/generated/java
-      org.eclipse.jdt.apt.reconcileEnabled=true
-    """.replaceFirst('\n','').stripIndent()
-    assertEquals(expected, prefsFile.text)
-  }
-
-  @Test
-  public void testEclipseAptPrefsUsesDefaultOutputDir() throws IOException {
-    buildFile << """
-      apply plugin: 'java'
-      apply plugin: 'eclipse'
-      apply plugin: 'org.inferred.processors'
-
-      dependencies {
-        processor 'org.immutables:value:2.0.21'
-      }
-
-      eclipse.classpath.defaultOutputDir = file('something')
-    """
-
-    new File(testProjectDir.newFolder('src', 'main', 'java'), 'MyClass.java') << """
-      import org.immutables.value.Value;
-
-      @Value.Immutable
-      public interface MyClass {
-        @Value.Parameter String getValue();
-      }
-    """
-
-    File testProjectDirRoot = testProjectDir.getRoot()
-
-    GradleRunner.create()
-            .withProjectDir(testProjectDirRoot)
-            .withArguments("eclipseAptPrefs")
-            .build()
-
-    def prefsFile = new File(testProjectDirRoot, ".settings/org.eclipse.jdt.apt.core.prefs")
-
-    def expected = """
-      eclipse.preferences.version=1
-      org.eclipse.jdt.apt.aptEnabled=true
-      org.eclipse.jdt.apt.genSrcDir=something/generated/java
+      org.eclipse.jdt.apt.genSrcDir=generated/java
       org.eclipse.jdt.apt.reconcileEnabled=true
     """.replaceFirst('\n','').stripIndent()
     assertEquals(expected, prefsFile.text)


### PR DESCRIPTION
Despite the sanity of outputting generated source into the "default output directory", apparently Eclipse refuses to compile with that setting. Output to generated/java instead.

We used to output to generated_src, same as gradle build, but there are adverse side-effects when the two processes share the same output location.

This fixes #56.