### PR TITLE
Revert Findbugs workaround

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -9,7 +9,6 @@ import org.gradle.api.artifacts.ResolvedConfiguration
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPlugin
-import org.gradle.api.plugins.quality.FindBugs
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Delete
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
@@ -136,23 +135,6 @@ class ProcessorsPlugin implements Plugin<Project> {
         }
       }
     }
-
-    /**** FindBugs ********************************************************************************/
-    project.tasks.withType(FindBugs, { task -> task.doFirst {
-      // Exclude generated sources from FindBugs' traversal.
-      // This trick relies on javac putting the generated .java files next to the .class files.
-      def generatedSources = task.classes.filter {
-        it.path.endsWith '.java'
-      }
-      task.classes = task.classes.filter {
-        File javaFile = new File(it.path
-            .replaceFirst(/\$\w+\.class$/, '')
-            .replaceFirst(/\.class$/, '')
-            + '.java')
-        boolean isGenerated = generatedSources.contains(javaFile)
-        return !isGenerated
-      }
-    }})
   }
 
   /** Runs {@code action} on element {@code name} in {@code collection} whenever it is added. */

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -151,7 +151,8 @@ public class ProcessorsPluginFunctionalTest {
       apply plugin: 'org.inferred.processors'
 
       dependencies {
-        processor 'org.immutables:value:2.0.21'
+        processor 'com.google.code.findbugs:findbugs-annotations:3.0.1'
+        processor 'org.immutables:value:2.1.12'
       }
     """
 


### PR DESCRIPTION
Instead bump Immutables dependency to 2.1.12 to
leverage https://github.com/immutables/immutables/issues/263.

Targets #47, #49, #50.