### PR TITLE
Fix directory-based IDEA projects

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -220,9 +220,8 @@ class ProcessorsPlugin implements Plugin<Project> {
     compilerConfiguration.annotationProcessing.replaceNode{
       annotationProcessing() {
         profile(default: 'true', name: 'Default', enabled: 'true') {
-          sourceOutputDir(name: getIdeaSourceOutputDir(project))
-          sourceTestOutputDir(name: getIdeaSourceTestOutputDir(project))
-          outputRelativeToContentRoot(value: 'true')
+          sourceOutputDir(name: '../../../' + getIdeaSourceOutputDir(project))
+          sourceTestOutputDir(name: '../../../' + getIdeaSourceTestOutputDir(project))
           processorPath(useClasspath: 'true')
         }
       }

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -561,9 +561,8 @@ public class ProcessorsPluginFunctionalTest {
         <component name="CompilerConfiguration">
           <annotationProcessing>
             <profile default="true" name="Default" enabled="true">
-              <sourceOutputDir name="generated_src"/>
-              <sourceTestOutputDir name="generated_testSrc"/>
-              <outputRelativeToContentRoot value="true"/>
+              <sourceOutputDir name="../../../generated_src"/>
+              <sourceTestOutputDir name="../../../generated_testSrc"/>
               <processorPath useClasspath="true"/>
             </profile>
           </annotationProcessing>
@@ -603,9 +602,8 @@ public class ProcessorsPluginFunctionalTest {
         <component name="CompilerConfiguration">
           <annotationProcessing>
             <profile default="true" name="Default" enabled="true">
-              <sourceOutputDir name="generated_src"/>
-              <sourceTestOutputDir name="generated_testSrc"/>
-              <outputRelativeToContentRoot value="true"/>
+              <sourceOutputDir name="../../../generated_src"/>
+              <sourceTestOutputDir name="../../../generated_testSrc"/>
               <processorPath useClasspath="true"/>
             </profile>
           </annotationProcessing>
@@ -651,9 +649,8 @@ public class ProcessorsPluginFunctionalTest {
         <component name="CompilerConfiguration">
           <annotationProcessing>
             <profile default="true" name="Default" enabled="true">
-              <sourceOutputDir name="foo"/>
-              <sourceTestOutputDir name="bar"/>
-              <outputRelativeToContentRoot value="true"/>
+              <sourceOutputDir name="../../../foo"/>
+              <sourceTestOutputDir name="../../../bar"/>
               <processorPath useClasspath="true"/>
             </profile>
           </annotationProcessing>
@@ -705,7 +702,7 @@ public class ProcessorsPluginFunctionalTest {
     def xml = new XmlSlurper().parse(testProjectDirRoot.toPath().resolve("${testProjectDirRoot.name}.ipr").toFile())
     def compilerConfiguration = xml.component.findResult { it.@name == "CompilerConfiguration" ? it : null }
     def profile = compilerConfiguration.annotationProcessing.profile.findResult { it.@name == "Default" ? it : null }
-    assertEquals(profile.sourceOutputDir.first().@name, "generated_src")
+    assertEquals(profile.sourceOutputDir.first().@name, "../../../generated_src")
   }
 
   /** @see https://github.com/palantir/gradle-processors/issues/12 */
@@ -782,9 +779,8 @@ public class ProcessorsPluginFunctionalTest {
         <component name="CompilerConfiguration">
           <annotationProcessing>
             <profile default="true" name="Default" enabled="true">
-              <sourceOutputDir name="generated_src"/>
-              <sourceTestOutputDir name="generated_testSrc"/>
-              <outputRelativeToContentRoot value="true"/>
+              <sourceOutputDir name="../../../generated_src"/>
+              <sourceTestOutputDir name="../../../generated_testSrc"/>
               <processorPath useClasspath="true"/>
             </profile>
           </annotationProcessing>
@@ -831,9 +827,8 @@ public class ProcessorsPluginFunctionalTest {
         <component name="CompilerConfiguration">
           <annotationProcessing>
             <profile default="true" name="Default" enabled="true">
-              <sourceOutputDir name="foo"/>
-              <sourceTestOutputDir name="bar"/>
-              <outputRelativeToContentRoot value="true"/>
+              <sourceOutputDir name="../../../foo"/>
+              <sourceTestOutputDir name="../../../bar"/>
               <processorPath useClasspath="true"/>
             </profile>
           </annotationProcessing>
@@ -883,9 +878,8 @@ public class ProcessorsPluginFunctionalTest {
         <component name="CompilerConfiguration">
           <annotationProcessing>
             <profile default="true" name="Default" enabled="true">
-              <sourceOutputDir name="generated_src"/>
-              <sourceTestOutputDir name="generated_testSrc"/>
-              <outputRelativeToContentRoot value="true"/>
+              <sourceOutputDir name="../../../generated_src"/>
+              <sourceTestOutputDir name="../../../generated_testSrc"/>
               <processorPath useClasspath="true"/>
             </profile>
           </annotationProcessing>


### PR DESCRIPTION
 "Output relative to content root" is broken in directory-based IDEA projects

As per #58, directory-based projects appear to redefine "Output relative to content root" to mean "Output relative to a totally random source root", resulting in our adding "generated_src" to the package of generated code. Selecting "Module output directory" and prepending `../../../` to the path seems to be more robust.