### PR TITLE
Use "Output relative to content root" again

### DIFF
--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -669,7 +669,7 @@ public class ProcessorsPluginFunctionalTest {
     File testProjectDirRoot = testProjectDir.getRoot()
     GradleRunner.create()
             .withProjectDir(testProjectDirRoot)
-            .withArguments("idea", "--stacktrace")
+            .withArguments("tasks", "--stacktrace")
             .build()
 
     def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
@@ -679,8 +679,9 @@ public class ProcessorsPluginFunctionalTest {
         <component name="CompilerConfiguration">
           <annotationProcessing>
             <profile default="true" name="Default" enabled="true">
-              <sourceOutputDir name="../../../generated_src"/>
-              <sourceTestOutputDir name="../../../generated_testSrc"/>
+              <sourceOutputDir name="../generated_src"/>
+              <sourceTestOutputDir name="../generated_testSrc"/>
+              <outputRelativeToContentRoot value="true"/>
               <processorPath useClasspath="true"/>
             </profile>
           </annotationProcessing>
@@ -710,7 +711,7 @@ public class ProcessorsPluginFunctionalTest {
     File testProjectDirRoot = testProjectDir.getRoot()
     GradleRunner.create()
             .withProjectDir(testProjectDirRoot)
-            .withArguments("idea", "--stacktrace")
+            .withArguments("tasks", "--stacktrace")
             .build()
 
     def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
@@ -720,8 +721,9 @@ public class ProcessorsPluginFunctionalTest {
         <component name="CompilerConfiguration">
           <annotationProcessing>
             <profile default="true" name="Default" enabled="true">
-              <sourceOutputDir name="../../../generated_src"/>
-              <sourceTestOutputDir name="../../../generated_testSrc"/>
+              <sourceOutputDir name="../generated_src"/>
+              <sourceTestOutputDir name="../generated_testSrc"/>
+              <outputRelativeToContentRoot value="true"/>
               <processorPath useClasspath="true"/>
             </profile>
           </annotationProcessing>
@@ -730,6 +732,32 @@ public class ProcessorsPluginFunctionalTest {
     """.stripIndent().trim()
 
     assertEquals(expected, xml)
+  }
+
+  @Test
+  public void testUserSpecifiedDirectoriesUsedInIdeaIprFile() throws IOException {
+    buildFile << """
+      apply plugin: 'java'
+      apply plugin: 'idea'
+      apply plugin: 'org.inferred.processors'
+
+      idea.processors {
+        outputDir = 'foo'
+        testOutputDir = 'bar'
+      }
+    """
+
+    File testProjectDirRoot = testProjectDir.getRoot()
+    GradleRunner.create()
+            .withProjectDir(testProjectDirRoot)
+            .withArguments("idea", "--stacktrace")
+            .build()
+
+    def xml = new XmlSlurper().parse(testProjectDirRoot.toPath().resolve("${testProjectDirRoot.name}.ipr").toFile())
+    def compilerConfiguration = xml.component.findResult { it.@name == "CompilerConfiguration" ? it : null }
+    def profile = compilerConfiguration.annotationProcessing.profile.findResult { it.@name == "Default" ? it : null }
+    assertEquals(profile.sourceOutputDir.first().@name, "foo")
+    assertEquals(profile.sourceTestOutputDir.first().@name, "bar")
   }
 
   @Test
@@ -757,7 +785,7 @@ public class ProcessorsPluginFunctionalTest {
     File testProjectDirRoot = testProjectDir.getRoot()
     GradleRunner.create()
             .withProjectDir(testProjectDirRoot)
-            .withArguments("idea", "--stacktrace")
+            .withArguments("tasks", "--stacktrace")
             .build()
 
     def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
@@ -767,8 +795,9 @@ public class ProcessorsPluginFunctionalTest {
         <component name="CompilerConfiguration">
           <annotationProcessing>
             <profile default="true" name="Default" enabled="true">
-              <sourceOutputDir name="../../../foo"/>
-              <sourceTestOutputDir name="../../../bar"/>
+              <sourceOutputDir name="../foo"/>
+              <sourceTestOutputDir name="../bar"/>
+              <outputRelativeToContentRoot value="true"/>
               <processorPath useClasspath="true"/>
             </profile>
           </annotationProcessing>
@@ -820,7 +849,7 @@ public class ProcessorsPluginFunctionalTest {
     def xml = new XmlSlurper().parse(testProjectDirRoot.toPath().resolve("${testProjectDirRoot.name}.ipr").toFile())
     def compilerConfiguration = xml.component.findResult { it.@name == "CompilerConfiguration" ? it : null }
     def profile = compilerConfiguration.annotationProcessing.profile.findResult { it.@name == "Default" ? it : null }
-    assertEquals(profile.sourceOutputDir.first().@name, "../../../generated_src")
+    assertEquals(profile.sourceOutputDir.first().@name, "generated_src")
   }
 
   /** @see https://github.com/palantir/gradle-processors/issues/12 */
@@ -897,8 +926,9 @@ public class ProcessorsPluginFunctionalTest {
         <component name="CompilerConfiguration">
           <annotationProcessing>
             <profile default="true" name="Default" enabled="true">
-              <sourceOutputDir name="../../../generated_src"/>
-              <sourceTestOutputDir name="../../../generated_testSrc"/>
+              <sourceOutputDir name="../generated_src"/>
+              <sourceTestOutputDir name="../generated_testSrc"/>
+              <outputRelativeToContentRoot value="true"/>
               <processorPath useClasspath="true"/>
             </profile>
           </annotationProcessing>
@@ -935,7 +965,7 @@ public class ProcessorsPluginFunctionalTest {
     File testProjectDirRoot = testProjectDir.getRoot()
     GradleRunner.create()
             .withProjectDir(testProjectDirRoot)
-            .withArguments("idea", "--stacktrace")
+            .withArguments("tasks", "--stacktrace")
             .build()
 
     def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
@@ -945,8 +975,9 @@ public class ProcessorsPluginFunctionalTest {
         <component name="CompilerConfiguration">
           <annotationProcessing>
             <profile default="true" name="Default" enabled="true">
-              <sourceOutputDir name="../../../foo"/>
-              <sourceTestOutputDir name="../../../bar"/>
+              <sourceOutputDir name="../foo"/>
+              <sourceTestOutputDir name="../bar"/>
+              <outputRelativeToContentRoot value="true"/>
               <processorPath useClasspath="true"/>
             </profile>
           </annotationProcessing>
@@ -986,7 +1017,7 @@ public class ProcessorsPluginFunctionalTest {
     File testProjectDirRoot = testProjectDir.getRoot()
     GradleRunner.create()
             .withProjectDir(testProjectDirRoot)
-            .withArguments("idea", "--stacktrace")
+            .withArguments("tasks", "--stacktrace")
             .build()
 
     def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
@@ -996,8 +1027,9 @@ public class ProcessorsPluginFunctionalTest {
         <component name="CompilerConfiguration">
           <annotationProcessing>
             <profile default="true" name="Default" enabled="true">
-              <sourceOutputDir name="../../../generated_src"/>
-              <sourceTestOutputDir name="../../../generated_testSrc"/>
+              <sourceOutputDir name="../generated_src"/>
+              <sourceTestOutputDir name="../generated_testSrc"/>
+              <outputRelativeToContentRoot value="true"/>
               <processorPath useClasspath="true"/>
             </profile>
           </annotationProcessing>


### PR DESCRIPTION
As per #66, using "Module output directory" and prepending `../../../` to the generated source path only works for top-level non-directory-based projects. Revert to using "Output relative to content root", and prepend a single `../` in directory-based IDEA projects to avoid regressing on #58.

This fixes #65 and fixes #66.