### PR TITLE
Bump publish plugin to 0.9.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java-gradle-plugin'
   id 'groovy'
   id 'idea'
-  id 'com.gradle.plugin-publish' version '0.9.1'
+  id 'com.gradle.plugin-publish' version '0.9.7'
   id 'com.palantir.git-version' version '0.2.0'
   id 'com.palantir.idea-test-fix' version '0.1.0'
 }


### PR DESCRIPTION
This fixes cert issues when publishing to plugins.gradle.org