### PR TITLE
Allow compiler.xml modification to be disabled

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -97,6 +97,7 @@ class ProcessorsPlugin implements Plugin<Project> {
           project.idea.processors {
             outputDir = 'generated_src'
             testOutputDir = 'generated_testSrc'
+            updateCompilerXml = true
           }
         }
 
@@ -126,8 +127,11 @@ class ProcessorsPlugin implements Plugin<Project> {
       // This file is only generated in the root project, but the user may not have applied
       //   the gradle-processors plugin to the root project. Instead, we update it from every
       //   project idempotently.
+      boolean updateCompilerXml = (!project.hasProperty('idea')
+              || !project.idea.hasProperty('processors')
+              || project.idea.processors.updateCompilerXml)
       File ideaCompilerXml = project.rootProject.file('.idea/compiler.xml')
-      if (ideaCompilerXml.isFile()) {
+      if (updateCompilerXml && ideaCompilerXml.isFile()) {
         Node parsedProjectXml = (new XmlParser()).parse(ideaCompilerXml)
         updateIdeaCompilerConfiguration(project.rootProject, parsedProjectXml, true)
         ideaCompilerXml.withWriter { writer ->
@@ -354,4 +358,5 @@ class EclipseProcessorsExtension {
 class IdeaProcessorsExtension {
   Object outputDir
   Object testOutputDir
+  boolean updateCompilerXml
 }

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -693,6 +693,37 @@ public class ProcessorsPluginFunctionalTest {
   }
 
   @Test
+  public void testAnnotationProcessingInIdeaCompilerXmlCanBeDisabled() throws IOException {
+    buildFile << """
+      apply plugin: 'java'
+      apply plugin: 'idea'
+      apply plugin: 'org.inferred.processors'
+
+      idea.processors.updateCompilerXml = false
+    """
+
+    def expected = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project version="4">
+        <component name="CompilerConfiguration">
+          <annotationProcessing/>
+        </component>
+      </project>
+    """.trim()
+    new File(testProjectDir.newFolder('.idea'), 'compiler.xml') << expected
+
+    File testProjectDirRoot = testProjectDir.getRoot()
+    GradleRunner.create()
+            .withProjectDir(testProjectDirRoot)
+            .withArguments("tasks", "--stacktrace")
+            .build()
+
+    def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
+
+    assertEquals(expected, xml)
+  }
+
+  @Test
   public void testNoAnnotationProcessingInIdeaCompilerXml() throws IOException {
     buildFile << """
       apply plugin: 'java'


### PR DESCRIPTION
Allow compiler.xml modification to be disabled by setting `idea.processors.modifyCompilerXml` to false on the root project. (You will need `apply plugin: idea` in your root project.)

See #68 