### PR TITLE
Only update .idea/compiler.xml if idea.active property set

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -122,12 +122,14 @@ class ProcessorsPlugin implements Plugin<Project> {
     })
 
     project.afterEvaluate {
-      // If the project uses .idea directory structure, update compiler.xml directly
+      // If the project uses .idea directory structure, and we are running within IntelliJ, update
+      //   compiler.xml directly
       // This file is only generated in the root project, but the user may not have applied
       //   the gradle-processors plugin to the root project. Instead, we update it from every
       //   project idempotently.
+      def inIntelliJ = System.properties.'idea.active' as boolean
       File ideaCompilerXml = project.rootProject.file('.idea/compiler.xml')
-      if (ideaCompilerXml.isFile()) {
+      if (inIntelliJ && ideaCompilerXml.isFile()) {
         Node parsedProjectXml = (new XmlParser()).parse(ideaCompilerXml)
         updateIdeaCompilerConfiguration(project.rootProject, parsedProjectXml, true)
         ideaCompilerXml.withWriter { writer ->

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -669,7 +669,7 @@ public class ProcessorsPluginFunctionalTest {
     File testProjectDirRoot = testProjectDir.getRoot()
     GradleRunner.create()
             .withProjectDir(testProjectDirRoot)
-            .withArguments("tasks", "--stacktrace")
+            .withArguments("-Didea.active=true", "--stacktrace")
             .build()
 
     def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
@@ -693,6 +693,36 @@ public class ProcessorsPluginFunctionalTest {
   }
 
   @Test
+  public void testCompilerXmlNotTouchedIfIdeaNotActive() throws IOException {
+    buildFile << """
+      apply plugin: 'java'
+      apply plugin: 'idea'
+      apply plugin: 'org.inferred.processors'
+    """
+
+    def expected = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project version="4">
+        <component name="CompilerConfiguration">
+          <annotationProcessing/>
+        </component>
+      </project>
+    """.trim()
+
+    new File(testProjectDir.newFolder('.idea'), 'compiler.xml') << expected
+
+    File testProjectDirRoot = testProjectDir.getRoot()
+    GradleRunner.create()
+            .withProjectDir(testProjectDirRoot)
+            .withArguments("--stacktrace")
+            .build()
+
+    def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
+
+    assertEquals(expected, xml)
+  }
+
+  @Test
   public void testNoAnnotationProcessingInIdeaCompilerXml() throws IOException {
     buildFile << """
       apply plugin: 'java'
@@ -711,7 +741,7 @@ public class ProcessorsPluginFunctionalTest {
     File testProjectDirRoot = testProjectDir.getRoot()
     GradleRunner.create()
             .withProjectDir(testProjectDirRoot)
-            .withArguments("tasks", "--stacktrace")
+            .withArguments("-Didea.active=true", "--stacktrace")
             .build()
 
     def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
@@ -785,7 +815,7 @@ public class ProcessorsPluginFunctionalTest {
     File testProjectDirRoot = testProjectDir.getRoot()
     GradleRunner.create()
             .withProjectDir(testProjectDirRoot)
-            .withArguments("tasks", "--stacktrace")
+            .withArguments("-Didea.active=true", "--stacktrace")
             .build()
 
     def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
@@ -916,7 +946,7 @@ public class ProcessorsPluginFunctionalTest {
     File testProjectDirRoot = testProjectDir.getRoot()
     GradleRunner.create()
             .withProjectDir(testProjectDirRoot)
-            .withArguments("tasks", "--stacktrace")
+            .withArguments("-Didea.active=true", "--stacktrace")
             .build()
 
     def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
@@ -965,7 +995,7 @@ public class ProcessorsPluginFunctionalTest {
     File testProjectDirRoot = testProjectDir.getRoot()
     GradleRunner.create()
             .withProjectDir(testProjectDirRoot)
-            .withArguments("tasks", "--stacktrace")
+            .withArguments("-Didea.active=true", "--stacktrace")
             .build()
 
     def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()
@@ -1017,7 +1047,7 @@ public class ProcessorsPluginFunctionalTest {
     File testProjectDirRoot = testProjectDir.getRoot()
     GradleRunner.create()
             .withProjectDir(testProjectDirRoot)
-            .withArguments("tasks", "--stacktrace")
+            .withArguments("-Didea.active=true", "--stacktrace")
             .build()
 
     def xml = testProjectDirRoot.toPath().resolve(".idea/compiler.xml").toFile().text.trim()


### PR DESCRIPTION
This stops us updating the XML file when the user isn't wanting IntelliJ integration.

See #68 