### PR TITLE
Lazily create processorPath tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ sourceCompatibility = '1.7'
 
 dependencies {
   compile localGroovy()
+  compile gradleApi()
   compile 'org.codehaus.groovy:groovy-backports-compat23:2.3.5'
   testCompile gradleTestKit()
 }

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -1,6 +1,6 @@
 package org.inferred.gradle
 
-import com.sun.xml.internal.ws.util.StringUtils
+
 import groovy.text.SimpleTemplateEngine
 import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectCollection
@@ -18,6 +18,7 @@ import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
+import org.gradle.util.GUtil
 
 class ProcessorsPlugin implements Plugin<Project> {
 
@@ -31,7 +32,7 @@ class ProcessorsPlugin implements Plugin<Project> {
       def convention = project.convention.plugins['java'] as JavaPluginConvention
       convention.sourceSets.all { it.compileClasspath += project.configurations.processor }
       project.tasks.withType(JavaCompile).all { JavaCompile compileTask ->
-        compileTask.dependsOn project.task('processorPath' + StringUtils.capitalize(compileTask.name), {
+        compileTask.dependsOn project.task(GUtil.toCamelCase('processorPath ' + compileTask.name), {
           doLast {
             String path = getProcessors(project).getAsPath()
             compileTask.options.compilerArgs += ["-processorpath", path]
@@ -39,7 +40,7 @@ class ProcessorsPlugin implements Plugin<Project> {
         })
       }
       project.tasks.withType(Javadoc).all { Javadoc javadocTask ->
-        javadocTask.dependsOn project.task('javadocProcessors' + StringUtils.capitalize(javadocTask.name), {
+        javadocTask.dependsOn project.task(GUtil.toCamelCase('javadocProcessors ' + javadocTask.name), {
           doLast {
             Set<File> path = getProcessors(project).files
             javadocTask.options.classpath += path

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -32,7 +32,7 @@ class ProcessorsPlugin implements Plugin<Project> {
       def convention = project.convention.plugins['java'] as JavaPluginConvention
       convention.sourceSets.all { it.compileClasspath += project.configurations.processor }
       project.tasks.withType(JavaCompile).all { JavaCompile compileTask ->
-        compileTask.dependsOn project.task(GUtil.toCamelCase('processorPath ' + compileTask.name), {
+        compileTask.dependsOn project.task(GUtil.toLowerCamelCase('processorPath ' + compileTask.name), {
           doLast {
             String path = getProcessors(project).getAsPath()
             compileTask.options.compilerArgs += ["-processorpath", path]
@@ -40,7 +40,7 @@ class ProcessorsPlugin implements Plugin<Project> {
         })
       }
       project.tasks.withType(Javadoc).all { Javadoc javadocTask ->
-        javadocTask.dependsOn project.task(GUtil.toCamelCase('javadocProcessors ' + javadocTask.name), {
+        javadocTask.dependsOn project.task(GUtil.toLowerCamelCase('javadocProcessors ' + javadocTask.name), {
           doLast {
             Set<File> path = getProcessors(project).files
             javadocTask.options.classpath += path

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -9,11 +9,12 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static org.hamcrest.CoreMatchers.containsString
+import static org.hamcrest.CoreMatchers.not
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
 
 public class ProcessorsPluginFunctionalTest {
 
@@ -357,8 +358,8 @@ public class ProcessorsPluginFunctionalTest {
         .withArguments("--info", "javadoc")
         .forwardStdError(stdErr)
         .build()
-    assertEquals(result.task(":javadoc").getOutcome(), SUCCESS);
-    assertEquals("", stdErr.toString());
+    assertEquals(result.task(":javadoc").getOutcome(), SUCCESS)
+    assertTrue(stdErr.toString().readLines().grep { !it.contains("_JAVA_OPTIONS") }.isEmpty())
   }
 
   @Test

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
@@ -1,14 +1,14 @@
 package org.inferred.gradle
 
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertTrue
-
-import org.junit.Test
-
-import org.gradle.api.Project
-import org.gradle.api.artifacts.ModuleDependency
-import org.gradle.testfixtures.ProjectBuilder
 
 class ProcessorsPluginTest {
 
@@ -77,5 +77,21 @@ class ProcessorsPluginTest {
 
     assertNotNull project.tasks.eclipseAptPrefs
     assertNotNull project.tasks.eclipseFactoryPath
+  }
+
+  @Test
+  public void picksUpNewSourceSets() {
+    Project project = ProjectBuilder.builder().build()
+    project.pluginManager.apply 'org.inferred.processors'
+    project.pluginManager.apply 'java'
+    getJavaConvention(project).sourceSets {
+      foo
+    }
+
+    assertTrue project.tasks.compileFooJava.dependsOn.contains(project.tasks.processorPathCompileFooJava)
+  }
+
+  private static JavaPluginConvention getJavaConvention(Project project) {
+    project.convention.plugins['java'] as JavaPluginConvention
   }
 }


### PR DESCRIPTION
This prevents a bug where sourceSets created after this plugin was applied were not being configured.