### PR TITLE
Correctly handle dir-base project when importing from Gradle

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -199,8 +199,7 @@ class ProcessorsPlugin implements Plugin<Project> {
       if (inIntelliJ && ideaCompilerXml.isFile()) {
         Node parsedProjectXml = (new XmlParser()).parse(ideaCompilerXml)
 
-        boolean useSeparateModulePerSourceSet = determineIfSeparateModulePerSourceSet(project)
-        updateIdeaCompilerConfiguration(project.rootProject, parsedProjectXml, useSeparateModulePerSourceSet)
+        updateIdeaCompilerConfiguration(project.rootProject, parsedProjectXml, determineIfSeparateModulePerSourceSet(project))
         ideaCompilerXml.withWriter { writer ->
           XmlNodePrinter nodePrinter = new XmlNodePrinter(new PrintWriter(writer))
           nodePrinter.setPreserveWhitespace(true)

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -196,21 +196,10 @@ class ProcessorsPlugin implements Plugin<Project> {
       //   project idempotently.
       def inIntelliJ = System.properties.'idea.active' as boolean
       File ideaCompilerXml = project.rootProject.file('.idea/compiler.xml')
-      File gradleConfigXml = project.rootProject.file(".idea/gradle.xml")
       if (inIntelliJ && ideaCompilerXml.isFile()) {
         Node parsedProjectXml = (new XmlParser()).parse(ideaCompilerXml)
 
-        def useSeparateModulePerSourceSet = gradleConfigXml.exists() \
-          ? new XmlSlurper().parse(gradleConfigXml)
-                .component
-                ?.find { it.@name == 'GradleSettings' }
-                ?.option
-                ?.find { it.@name == 'linkedExternalProjectsSettings' }
-                ?.GradleProjectSettings
-                ?.option
-                ?.find { it.@name == 'resolveModulePerSourceSet' }
-                ?.@value != "false" // Assume true if it's unset. this is IntelliJ's behaviour
-          : true
+        boolean useSeparateModulePerSourceSet = determineIfSeparateModulePerSourceSet(project)
         updateIdeaCompilerConfiguration(project.rootProject, parsedProjectXml, useSeparateModulePerSourceSet)
         ideaCompilerXml.withWriter { writer ->
           XmlNodePrinter nodePrinter = new XmlNodePrinter(new PrintWriter(writer))
@@ -219,6 +208,32 @@ class ProcessorsPlugin implements Plugin<Project> {
         }
       }
     }
+  }
+
+  /**
+   * Attempt to determine if we are <a href="https://www.jetbrains.com/help/idea/gradle.html">importing from within
+   * IntelliJ</a>, and if so, whether `resolveModulePerSourceSet` is enabled. We do this by checking the
+   * `.idea/gradle.xml` file.
+   * <p>
+   * If there is no such file, this method returns true, to match previous behaviour.
+   */
+  private static boolean determineIfSeparateModulePerSourceSet(Project project) {
+    // This gradle.xml file won't exist unless the project was imported from IntelliJ as a gradle project.
+    // That is a different workflow from `./gradlew idea`.
+    // See 'resolveModulePerSourceSet' definition in IntelliJ codebase:
+    // https://github.com/JetBrains/intellij-community/blob/a38503dc884986dc66675986df691318adeb0efc/plugins/gradle/src/org/jetbrains/plugins/gradle/settings/GradleProjectSettings.java#L29
+    File gradleConfigXml = project.rootProject.file(".idea/gradle.xml")
+    return gradleConfigXml.exists() \
+        ? new XmlSlurper().parse(gradleConfigXml)
+            .component
+            ?.find { it.@name == 'GradleSettings' }
+            ?.option
+            ?.find { it.@name == 'linkedExternalProjectsSettings' }
+            ?.GradleProjectSettings
+            ?.option
+            ?.find { it.@name == 'resolveModulePerSourceSet' }
+            ?.@value != "false" // Assume true if it's unset. this is IntelliJ's behaviour
+        : true
   }
 
   private static void configureFindBugs(Project project) {

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -633,7 +633,7 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
           <annotationProcessing/>
         </component>
       </project>
-    """.trim()
+    """.stripIndent().trim()
 
     runTasksSuccessfully("-Didea.active=true", "--stacktrace")
 
@@ -657,6 +657,59 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
     expect:
     expected == xml
   }
+
+  void testAnnotationProcessingInIdeaCompilerXml_separateModulePerSourceSetFalse() throws IOException {
+    buildFile << """
+      apply plugin: 'java'
+      apply plugin: 'idea'
+      apply plugin: 'org.inferred.processors'
+    """
+
+    file('.idea/compiler.xml') << """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project version="4">
+        <component name="CompilerConfiguration">
+          <annotationProcessing/>
+        </component>
+      </project>
+    """.stripIndent().trim()
+
+    file('.idea/gradle.xml') << """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project version="4">
+        <component name="GradleSettings">
+          <option name="linkedExternalProjectsSettings">
+            <GradleProjectSettings>
+              <option name="resolveModulePerSourceSet" value="false" />
+            </GradleProjectSettings>
+          </option>
+        </component>
+      </project>
+    """.stripIndent().trim()
+
+    with("-Didea.active=true", "--stacktrace").withDebug(true).build()
+
+    def xml = file(".idea/compiler.xml").text.trim()
+
+    def expected = """
+      <project version="4">
+        <component name="CompilerConfiguration">
+          <annotationProcessing>
+            <profile default="true" name="Default" enabled="true">
+              <sourceOutputDir name="generated_src"/>
+              <sourceTestOutputDir name="generated_testSrc"/>
+              <outputRelativeToContentRoot value="true"/>
+              <processorPath useClasspath="true"/>
+            </profile>
+          </annotationProcessing>
+        </component>
+      </project>
+    """.stripIndent().trim()
+
+    expect:
+    expected == xml
+  }
+
 
   void testCompilerXmlNotTouchedIfIdeaNotActive() throws IOException {
     buildFile << """

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -687,7 +687,7 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
       </project>
     """.stripIndent().trim()
 
-    with("-Didea.active=true", "--stacktrace").withDebug(true).build()
+    runTasksSuccessfully("-Didea.active=true", "--stacktrace")
 
     def xml = file(".idea/compiler.xml").text.trim()
 


### PR DESCRIPTION
## Before this PR

When importing from IntelliJ and _not_ using separate module per source set, the output paths for annotation processors were wrong.
They would point to `../generatedSrc` and `../generated_testSrc` which would end up outside the module (and shared by all subprojects at the same level).

Those paths are only appropriate when importing with 'use separate module per source set'.

## After this PR

We parse the `.idea/gradle.xml` file to determine if separate modules are used or not, and change the output paths accordingly.
Namely, if they are not used, then the output paths should just be in the current directory e.g. `generatedSrc`.