### PR TITLE
[break] Stop making compileOnly extend annotationProcessor

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -75,10 +75,6 @@ class ProcessorsPlugin implements Plugin<Project> {
         def annotationProcessorConf = project.configurations[sourceSet.annotationProcessorConfigurationName]
         annotationProcessorConf.extendsFrom ourProcessorsConf
         allProcessorsConf.extendsFrom annotationProcessorConf
-        // Preserve previously agreed behaviour where just adding something to `annotationProcessor` would add it to the
-        // compile classpath as well, to make testAnnotationProcessor pass
-        project.configurations[sourceSet.compileOnlyConfigurationName].extendsFrom(
-                project.configurations.annotationProcessor)
       }
     } else {
       project.tasks.withType(JavaCompile).all { JavaCompile compileTask ->

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -53,6 +53,7 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
 
       dependencies {
         annotationProcessor 'com.google.auto.value:auto-value:1.0'
+        compileOnly 'com.google.auto.value:auto-value-annotations:1.0'
       }
     """
 

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -52,8 +52,8 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
       apply plugin: 'org.inferred.processors'
 
       dependencies {
-        annotationProcessor 'com.google.auto.value:auto-value:1.0'
-        compileOnly 'com.google.auto.value:auto-value-annotations:1.0'
+        annotationProcessor 'com.google.auto.value:auto-value:1.6.2'
+        compileOnly 'com.google.auto.value:auto-value-annotations:1.6.2'
       }
     """
 


### PR DESCRIPTION
## Before this PR

We have a hack where we make `compileOnly` extend `processor` for convenience.
We also applied this hack to the `annotationProcessor` configuration.
However, this impacts more things now - e.g. the errorprone plugin [adds itself as a dependency to `annotationProcessor`](https://github.com/tbroyer/gradle-errorprone-plugin/blob/d36cf009776592cd6bed22d49a3265583a3d8d2f/src/main/kotlin/net/ltgt/gradle/errorprone/ErrorPronePlugin.kt#L108) which means you get all of errorprone and its dependencies in your `compileClasspath`.

## After this PR

`compileOnly` no longer extends from `annotationProcessor`.
Users who use an annotation processor should also add the corresponding runtime-annotations-only dependency to `compileOnly` themselves:

```diff
 dependencies {
     annotationProcessor 'com.google.auto.value:auto-value:1.6.2'
+    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.2'
 }
```