### PR TITLE
[improvement] Configure annotation processor classpath explicitly in IDEA

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -8,6 +8,7 @@ import org.gradle.api.XmlProvider
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedConfiguration
 import org.gradle.api.file.FileCollection
+import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginConvention
@@ -21,6 +22,7 @@ import org.gradle.plugins.ide.api.XmlFileContentMerger
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.plugins.ide.idea.model.IdeaModel
+import org.gradle.plugins.ide.idea.model.IdeaModule
 import org.gradle.util.GUtil
 
 class ProcessorsPlugin implements Plugin<Project> {
@@ -49,7 +51,7 @@ class ProcessorsPlugin implements Plugin<Project> {
         project.configurations[sourceSet.compileOnlyConfigurationName].extendsFrom ourProcessorConf
       }
 
-      configureIdeaPlugin(project, allProcessorsConf)
+      configureIdeaPlugin(project, ourProcessorConf, allProcessorsConf)
       configureFindBugs(project)
       configureJacoco(project)
     })
@@ -153,36 +155,31 @@ class ProcessorsPlugin implements Plugin<Project> {
     }
   }
 
-  private void configureIdeaPlugin(Project project, Configuration allProcessorConf) {
+  private void configureIdeaPlugin(Project project, Configuration ourProcessorConf, Configuration allProcessorConf) {
     project.plugins.withType(IdeaPlugin, { plugin ->
-      if (project == project.rootProject) {
-        // Generated source directories can only be specified per-workspace in IntelliJ.
-        // As such, it only makes sense to allow the user to configure them on the root project.
-        // If the gradle-processors plugin is not applied to the root project, we just use
-        //   the default values.
-        project.idea.extensions.create('processors', IdeaProcessorsExtension)
-        project.idea.processors {
-          outputDir = 'generated_src'
-          testOutputDir = 'generated_testSrc'
-        }
+      IdeaModel idea = project.extensions.getByType(IdeaModel)
+      def extension = (idea as ExtensionAware).extensions.create('processors', IdeaProcessorsExtension)
+      extension.with {
+        outputDir = 'generated_src'
+        testOutputDir = 'generated_testSrc'
       }
 
-      if (project.idea.module.scopes.PROVIDED != null) {
-        project.idea.module.scopes.PROVIDED.plus += [allProcessorConf]
+      if (idea.module.scopes.PROVIDED != null) {
+        idea.module.scopes.PROVIDED.plus += [ourProcessorConf]
       }
 
       addGeneratedSourceFolder(project, { getIdeaSourceOutputDir(project) }, false)
       addGeneratedSourceFolder(project, { getIdeaSourceTestOutputDir(project) }, true)
 
       // Root project configuration
-      def ideaModel = project.rootProject.extensions.findByType(IdeaModel)
-      if (ideaModel != null && ideaModel.project != null) {
-        project.rootProject.extensions.getByType(IdeaModel).project.ipr { XmlFileContentMerger merger ->
+      def rootModel = project.rootProject.extensions.findByType(IdeaModel)
+      if (rootModel != null && rootModel.project != null) {
+        rootModel.project.ipr { XmlFileContentMerger merger ->
           merger.withXml { XmlProvider it ->
             // This file is only generated in the root project, but the user may not have applied
-            //   the gradle-processors plugin to the root project. Instead, we update it from
-            //   every project idempotently.
-            updateIdeaCompilerConfiguration(project.rootProject, it.asNode(), allProcessorConf)
+            //   the gradle-processors plugin to the root project.
+            // In either case, we add a distinct profile for each project.
+            setupIdeaAnnotationProcessing(project, idea.module, it.asNode(), allProcessorConf)
           }
         }
       }
@@ -288,9 +285,9 @@ class ProcessorsPlugin implements Plugin<Project> {
     }
   }
 
-  static void updateIdeaCompilerConfiguration(
-      Project project, Node projectConfiguration, Configuration processorsConfiguration) {
-    Object compilerConfiguration = projectConfiguration.component
+  static void setupIdeaAnnotationProcessing(
+      Project project, IdeaModule ideaModule, Node projectConfiguration, Configuration processorsConfiguration) {
+    Node compilerConfiguration = projectConfiguration.component
             .find { it.@name == 'CompilerConfiguration' }
 
     if (compilerConfiguration == null) {
@@ -301,18 +298,23 @@ class ProcessorsPlugin implements Plugin<Project> {
       new Node(compilerConfiguration, "annotationProcessing")
     }
 
-    compilerConfiguration.annotationProcessing.replaceNode{
-      annotationProcessing() {
-        profile(default: 'true', name: 'Default', enabled: 'true') {
-          sourceOutputDir(name: getIdeaSourceOutputDir(project))
-          sourceTestOutputDir(name: getIdeaSourceTestOutputDir(project))
-          outputRelativeToContentRoot(value: 'true')
-          processorPath(useClasspath: 'false') {
-            processorsConfiguration.forEach {
-              entry(name: it.absolutePath)
-            }
+    project.logger.info("Configuring annotationProcessing profile for ${ideaModule.name}")
+
+    // Add a profile specifically for this module, or re-use an existing profile for that module
+    Node processingNode = (compilerConfiguration.annotationProcessing as NodeList).first()
+    def profileForModule = processingNode.profile.find { it.module.any { it.@name == ideaModule.name } }
+        ?: processingNode.appendNode('profile')
+    profileForModule.replaceNode {
+      profile(name: project.path, enabled: 'true') {
+        sourceOutputDir(name: getIdeaSourceOutputDir(project))
+        sourceTestOutputDir(name: getIdeaSourceTestOutputDir(project))
+        outputRelativeToContentRoot(value: 'true')
+        processorPath(useClasspath: 'false') {
+          processorsConfiguration.forEach {
+            entry(name: it.absolutePath)
           }
         }
+        module(name: ideaModule.name)
       }
     }
   }

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -155,7 +155,8 @@ class ProcessorsPlugin implements Plugin<Project> {
     }
   }
 
-  private void configureIdeaPlugin(Project project, Configuration ourProcessorConf, Configuration allProcessorConf) {
+  private static void configureIdeaPlugin(
+      Project project, Configuration ourProcessorConf, Configuration allProcessorConf) {
     project.plugins.withType(IdeaPlugin, { plugin ->
       IdeaModel idea = project.extensions.getByType(IdeaModel)
       def extension = (idea as ExtensionAware).extensions.create('processors', IdeaProcessorsExtension)

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -51,7 +51,7 @@ class ProcessorsPlugin implements Plugin<Project> {
         project.configurations[sourceSet.compileOnlyConfigurationName].extendsFrom ourProcessorConf
       }
 
-      configureIdeaPlugin(project, ourProcessorConf, allProcessorsConf)
+      configureIdeaPlugin(project, allProcessorsConf)
       configureFindBugs(project)
       configureJacoco(project)
     })
@@ -155,18 +155,13 @@ class ProcessorsPlugin implements Plugin<Project> {
     }
   }
 
-  private static void configureIdeaPlugin(
-      Project project, Configuration ourProcessorConf, Configuration allProcessorConf) {
+  private static void configureIdeaPlugin(Project project, Configuration allProcessorConf) {
     project.plugins.withType(IdeaPlugin, { plugin ->
       IdeaModel idea = project.extensions.getByType(IdeaModel)
       def extension = (idea as ExtensionAware).extensions.create('processors', IdeaProcessorsExtension)
       extension.with {
         outputDir = 'generated_src'
         testOutputDir = 'generated_testSrc'
-      }
-
-      if (idea.module.scopes.PROVIDED != null) {
-        idea.module.scopes.PROVIDED.plus += [ourProcessorConf]
       }
 
       addGeneratedSourceFolder(project, { getIdeaSourceOutputDir(project) }, false)

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -182,7 +182,7 @@ class ProcessorsPlugin implements Plugin<Project> {
             // This file is only generated in the root project, but the user may not have applied
             //   the gradle-processors plugin to the root project. Instead, we update it from
             //   every project idempotently.
-            updateIdeaCompilerConfiguration(project.rootProject, it.asNode())
+            updateIdeaCompilerConfiguration(project.rootProject, it.asNode(), allProcessorConf)
           }
         }
       }
@@ -288,7 +288,8 @@ class ProcessorsPlugin implements Plugin<Project> {
     }
   }
 
-  static void updateIdeaCompilerConfiguration(Project project, Node projectConfiguration) {
+  static void updateIdeaCompilerConfiguration(
+      Project project, Node projectConfiguration, Configuration processorsConfiguration) {
     Object compilerConfiguration = projectConfiguration.component
             .find { it.@name == 'CompilerConfiguration' }
 
@@ -306,7 +307,11 @@ class ProcessorsPlugin implements Plugin<Project> {
           sourceOutputDir(name: getIdeaSourceOutputDir(project))
           sourceTestOutputDir(name: getIdeaSourceTestOutputDir(project))
           outputRelativeToContentRoot(value: 'true')
-          processorPath(useClasspath: 'true')
+          processorPath(useClasspath: 'false') {
+            processorsConfiguration.forEach {
+              entry(name: it.absolutePath)
+            }
+          }
         }
       }
     }

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -750,7 +750,7 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
 
     def xml = new XmlSlurper().parse(file("${projectDir.name}.ipr"))
     def compilerConfiguration = xml.component.findResult { it.@name == "CompilerConfiguration" ? it : null }
-    def profile = compilerConfiguration.annotationProcessing.profile.findResult { it.@name == "Default" ? it : null }
+    def profile = compilerConfiguration.annotationProcessing.profile.findResult { it.@name == ":" ? it : null }
     expect:
     profile.sourceOutputDir.first().@name == "foo"
     profile.sourceTestOutputDir.first().@name == "bar"
@@ -779,7 +779,7 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
 
     def xml = new XmlSlurper().parse(file("${projectDir.name}.ipr"))
     def compilerConfiguration = xml.component.findResult { it.@name == "CompilerConfiguration" ? it : null }
-    def profile = compilerConfiguration.annotationProcessing.profile.findResult { it.@name == "Default" ? it : null }
+    def profile = compilerConfiguration.annotationProcessing.profile.findResult { it.@name == ":projectB" ? it : null }
 
     expect:
     profile.sourceOutputDir.first().@name == "generated_src"

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -647,7 +647,7 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
     profiles.each {
       with(it) {
         it.processorPath.first().@useClasspath == 'false'
-        !it.processorPath.entry.isEmpty()
+        it.processorPath.first().entry.collect { it.@name.text() }.any { it.contains 'value-2.0.21.jar' }
       }
     }
 

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
@@ -1,6 +1,5 @@
 package org.inferred.gradle
 
-
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.testfixtures.ProjectBuilder


### PR DESCRIPTION
## Before this PR

Currently, we configure a global "profile" for annotation processors in IDEA.
This profile instructs IDEA to pick up annotation processors from the classpath. At the same time, we manually add all dependencies from the `processor` configuration to the PROVIDED scope in IDEA.

This becomes problematic when an annotation processor brings in a different version of a library that already exists on your classpath. Now you get duplicates and behaviour is unexpected as it's not obvious which one will be used during compilation.

Additionally, this leaks all annotation processor dependencies (which are supposed to be implementation details as far as the rest of the program is concerned) onto your PROVIDED scope, so you could accidentally use a class that's not actually in your runtime configuration.

## After this PR

The IDEA project is configured with one profile per gradle project, which is assigned to the corresponding IDEA module, and each project's complete set of annotation processors (configuration `allProcessors`) are enumerated in this profile.

Furthermore, we don't make IDEA's PROVIDED scope extend `allProcessors` anymore.
This means that processors added to gradle 4.6+'s `annotationProcessor` configuration (and equivalents for source sets other than `main`) don't leak onto your PROVIDED scope anymore.

However, we still add dependencies from the original `processor` configuration to PROVIDED in an effort to keep backwards compatibility.

Example diff for gradle-sls-packaging:

```diff
-   <profile default="true" name="Default" enabled="true">
+   <profile name=":gradle-sls-packaging" enabled="true">
        <sourceOutputDir name="generated_src"/>
        <sourceTestOutputDir name="generated_testSrc"/>
        <outputRelativeToContentRoot value="true"/>
-       <processorPath useClasspath="true"/>
+       <processorPath useClasspath="false">
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/org.immutables/value/2.7.1/7879e75c53074fd8cbbe014bfa5e8689f8c565ae/value-2.7.1.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.palantir.baseline/baseline-error-prone/0.37.4/5b2e810d8335af8a105bda5ebf546ae0684dbefa/baseline-error-prone-0.37.4.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_core/2.3.2/d5d121a23bcd48df2fe42dc3f1424cd05872993/error_prone_core-2.3.2.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_check_api/2.3.2/7415438c00adec8ba707689ec4168c8484d8403b/error_prone_check_api-2.3.2.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_annotation/2.3.2/7c554c59dd2ea8c4e9e36b3308f8bf92db83e70c/error_prone_annotation-2.3.2.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_type_annotations/2.3.2/e79e88b9051888c8ea806f49c86fa7e3e3728180/error_prone_type_annotations-2.3.2.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.github.stephenc.jcip/jcip-annotations/1.0-1/ef31541dd28ae2cefdd17c7ebf352d93e9058c63/jcip-annotations-1.0-1.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/org.pcollections/pcollections/2.1.2/15925fd6c32a29fe3f40a048d238c5ca58cb8362/pcollections-2.1.2.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.google.auto/auto-common/0.10/c8f153ebe04a17183480ab4016098055fb474364/auto-common-0.10.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/23.6.1-jre/c18ab06b4b7646be581211ad59be1b6e1ea4c278/guava-23.6.1-jre.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.google.code.findbugs/jFormatString/3.0.0/d3995f9be450813bc2ccee8f0774c1a3033a0f30/jFormatString-3.0.0.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/3.0.2/25ea2e8b0c338a877313bd4672d3fe056ea78f0d/jsr305-3.0.2.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/org.checkerframework/dataflow/2.5.3/edf284e0838290d661b22483ecf648065e7ec440/dataflow-2.5.3.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_annotations/2.3.2/d1a0c5032570e0f64be6b4d9c90cdeb103129029/error_prone_annotations-2.3.2.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.google.protobuf/protobuf-java/3.4.0/b32aba0cbe737a4ca953f71688725972e3ee927c/protobuf-java-3.4.0.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.googlecode.java-diff-utils/diffutils/1.3.0/7e060dd5b19431e6d198e91ff670644372f60fbd/diffutils-1.3.0.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.github.kevinstern/software-and-algorithms/1.0/5e77666b72c6c5dd583c36148d17fc47f944dfb5/software-and-algorithms-1.0.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/org.checkerframework/checker-compat-qual/2.0.0/fc89b03860d11d6213d0154a62bcd1c2f69b9efa/checker-compat-qual-2.0.0.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.1/ed28ded51a8b1c6b112568def5f4b455e6809019/j2objc-annotations-1.1.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/org.codehaus.mojo/animal-sniffer-annotations/1.14/775b7e22fb10026eed3f86e8dc556dfafe35f2d5/animal-sniffer-annotations-1.14.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/org.checkerframework/javacutil/2.5.3/c545ca6fc7a57e3bc65d46e8e9438376f0db35ea/javacutil-2.5.3.jar"/>
+           <entry name="/Users/dsanduleac/.gradle/caches/modules-2/files-2.1/org.checkerframework/checker-qual/2.5.3/4fe154d21bd734fe8c94ada37cdc41a9a6d61776/checker-qual-2.5.3.jar"/>
+       </processorPath>
+       <module name="gradle-sls-packaging"/>
    </profile>
```