### PR TITLE
Add support for Eclipse's new test source output directory

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -107,7 +107,10 @@ class ProcessorsPlugin implements Plugin<Project> {
           project.eclipse {
             extensions.create('processors', EclipseProcessorsExtension)
             processors.conventionMapping.outputDir = {
-              project.file('generated/java')
+              project.file('generated/main/java')
+            }
+            processors.conventionMapping.testOutputDir = {
+              project.file('generated/test/java')
             }
 
             // If this is empty, then it means EclipsePlugin didn't initialize it yet
@@ -132,6 +135,7 @@ class ProcessorsPlugin implements Plugin<Project> {
                   {
                     [
                             outputDir: project.relativePath(project.eclipse.processors.outputDir).replace('\\', '\\\\'),
+                            testOutputDir: project.relativePath(project.eclipse.processors.testOutputDir).replace('\\', '\\\\'),
                             deps     : allProcessorConf
                     ]
                   }
@@ -383,6 +387,7 @@ class ProcessorsExtension {
 
 class EclipseProcessorsExtension {
   Object outputDir
+  Object testOutputDir
 }
 
 class IdeaProcessorsExtension {

--- a/src/main/resources/org/inferred/gradle/apt-prefs.template
+++ b/src/main/resources/org/inferred/gradle/apt-prefs.template
@@ -2,6 +2,7 @@ eclipse.preferences.version=1
 <% if (!deps.empty) { %>\
 org.eclipse.jdt.apt.aptEnabled=true
 org.eclipse.jdt.apt.genSrcDir=${outputDir}
+org.eclipse.jdt.apt.genTestSrcDir=${testOutputDir}
 org.eclipse.jdt.apt.reconcileEnabled=true
 <% } else { %>\
 org.eclipse.jdt.apt.aptEnabled=false


### PR DESCRIPTION
## Before this PR

Eclipse generated source is output to `generated/java`. Eclipse's new generated test source output directory configuration is left blank.

## After this PR

Eclipse is configured to output to `generated/main/java` and `generated/test/java` (in line with Gradle's conventional `src/main/java` and `src/test/java`).