### PR TITLE
Fix tests

### DIFF
--- a/src/test/groovy/org/inferred/gradle/AbstractSpec.groovy
+++ b/src/test/groovy/org/inferred/gradle/AbstractSpec.groovy
@@ -4,32 +4,20 @@
 
 package org.inferred.gradle
 
-import groovy.transform.CompileStatic
-import groovy.transform.TypeCheckingMode
-import nebula.test.multiproject.MultiProjectIntegrationHelper
+
+import nebula.test.IntegrationTestKitSpec
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
 
-class AbstractPluginTest extends Specification {
+class AbstractPluginTest extends IntegrationTestKitSpec {
 
-  @Rule
-  TemporaryFolder folder = new TemporaryFolder()
-
-  File buildFile
-  File settingsFile
-  MultiProjectIntegrationHelper multiProject
-  File projectDir
   String gradleVersion
 
   def setup() {
-    projectDir = folder.getRoot()
-    buildFile = file('build.gradle')
-    settingsFile = file('settings.gradle')
+    keepFiles = true
+    // Necessary when using gradle 5+
+    settingsFile.createNewFile()
     println("Build directory: \n" + projectDir.absolutePath)
-    multiProject = new MultiProjectIntegrationHelper(projectDir, settingsFile)
   }
 
   GradleRunner with(String... tasks) {
@@ -59,27 +47,13 @@ class AbstractPluginTest extends Specification {
     return proc.exitValue() == 0
   }
 
-  @CompileStatic(TypeCheckingMode.SKIP)
-  protected File createFile(String path, File baseDir = projectDir) {
-    File file = file(path, baseDir)
-    assert !file.exists()
-    file.parentFile.mkdirs()
-    assert file.createNewFile()
-    return file
-  }
-
+  /** Intentionally overwritten as {@link nebula.test.BaseIntegrationSpec#file} creates the file */
+  @Override
   protected File file(String path, File baseDir = projectDir) {
     def splitted = path.split('/')
     def directory = splitted.size() > 1 ? directory(splitted[0..-2].join('/'), baseDir) : baseDir
     def file = new File(directory, splitted[-1])
     return file
-  }
-
-  protected File directory(String path, File baseDir = projectDir) {
-    return new File(baseDir, path).with {
-      mkdirs()
-      return it
-    }
   }
 
   protected BuildResult runTasksSuccessfully(String... tasks) {

--- a/src/test/groovy/org/inferred/gradle/AbstractSpec.groovy
+++ b/src/test/groovy/org/inferred/gradle/AbstractSpec.groovy
@@ -6,11 +6,13 @@ package org.inferred.gradle
 
 
 import nebula.test.IntegrationTestKitSpec
+import nebula.test.multiproject.MultiProjectIntegrationHelper
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 
 class AbstractPluginTest extends IntegrationTestKitSpec {
 
+  MultiProjectIntegrationHelper multiProject
   String gradleVersion
 
   def setup() {
@@ -18,6 +20,7 @@ class AbstractPluginTest extends IntegrationTestKitSpec {
     // Necessary when using gradle 5+
     settingsFile.createNewFile()
     println("Build directory: \n" + projectDir.absolutePath)
+    multiProject = new MultiProjectIntegrationHelper(projectDir, settingsFile)
   }
 
   GradleRunner with(String... tasks) {

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -105,6 +105,7 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
 
   @Unroll
   void 'testJavaTestCompilation for gradle #gradleVersion'() throws IOException {
+    this.gradleVersion = gradleVersion
     buildFile << """
       apply plugin: 'org.inferred.processors'
       apply plugin: 'java'


### PR DESCRIPTION
## Before this PR

Due to us using a hand crafted gradle testkit-based test runner, test folders disappeared after running the test so couldn't inspect them.

## After this PR

Migrated to nebula-test's `GradleTestKitSpec` so we get nice things for free

Fix `testJavaTestCompilation for gradle #gradleVersion` to actually run against gradle 4.6

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
