### PR TITLE
Remove annotation processor dependencies from IDEA scopes

### DIFF
--- a/changelog/@unreleased/pr-144.v2.yml
+++ b/changelog/@unreleased/pr-144.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Remove annotation processor dependencies from IDEA scopes.
+  links:
+  - https://github.com/palantir/gradle-processors/pull/144

--- a/changelog/@unreleased/pr-144.v2.yml
+++ b/changelog/@unreleased/pr-144.v2.yml
@@ -1,5 +1,7 @@
 type: improvement
 improvement:
-  description: Remove annotation processor dependencies from IDEA scopes.
+  description: Remove annotation processor dependencies from IDEA scopes, to avoid
+    potentially getting two different versions of the same jar in your PROVIDED or
+    TEST scopes in IDEA (one from `(test)annotationProcessor`, one from `(test)compileClasspath`).
   links:
   - https://github.com/palantir/gradle-processors/pull/144

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -21,6 +21,8 @@ import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.gradle.plugins.ide.idea.model.IdeaModule
+import org.gradle.plugins.ide.idea.model.internal.GeneratedIdeaScope
+import org.gradle.plugins.ide.idea.model.internal.IdeaDependenciesProvider
 import org.gradle.util.GradleVersion
 
 class ProcessorsPlugin implements Plugin<Project> {
@@ -153,6 +155,15 @@ class ProcessorsPlugin implements Plugin<Project> {
 
       addGeneratedSourceFolder(project, { getIdeaSourceOutputDir(project) }, false)
       addGeneratedSourceFolder(project, { getIdeaSourceTestOutputDir(project) }, true)
+
+      idea.module.scopes
+              .get(GeneratedIdeaScope.PROVIDED.name())
+              .get(IdeaDependenciesProvider.SCOPE_PLUS)
+              .remove(JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME)
+      idea.module.scopes
+              .get(GeneratedIdeaScope.TEST.name())
+              .get(IdeaDependenciesProvider.SCOPE_PLUS)
+              .remove(JavaPlugin.TEST_ANNOTATION_PROCESSOR_CONFIGURATION_NAME)
 
       // Root project configuration
       def rootModel = project.rootProject.extensions.findByType(IdeaModel)

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -156,6 +156,9 @@ class ProcessorsPlugin implements Plugin<Project> {
       addGeneratedSourceFolder(project, { getIdeaSourceOutputDir(project) }, false)
       addGeneratedSourceFolder(project, { getIdeaSourceTestOutputDir(project) }, true)
 
+      // We need to remove the configurations from the plus configurations.
+      // If we instead added the configurations from the minus configurations, then that would remove dependencies that
+      // are shared with other configurations in the plus configurations.
       idea.module.scopes
               .get(GeneratedIdeaScope.PROVIDED.name())
               .get(IdeaDependenciesProvider.SCOPE_PLUS)

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
@@ -1,19 +1,18 @@
 package org.inferred.gradle
 
 import org.gradle.api.Project
-import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.Ignore
 import org.junit.Test
 
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertTrue
 
 class ProcessorsPluginTest {
 
   @Test
-  public void addsProcessorDependenciesToJavaClasspath() {
+  void addsProcessorDependenciesToJavaClasspath() {
     Project project = ProjectBuilder.builder().build()
     project.pluginManager.apply 'org.inferred.processors'
     project.pluginManager.apply 'java'
@@ -23,18 +22,18 @@ class ProcessorsPluginTest {
   }
 
   @Test
-  public void addsSourceDirectoryConfiguration() {
+  void addsSourceDirectoryConfiguration() {
     Project project = ProjectBuilder.builder().build()
     project.pluginManager.apply 'org.inferred.processors'
-    project.pluginManager.apply 'idea'
     project.pluginManager.apply 'java'
+    project.pluginManager.apply 'idea'
 
     assertEquals 'generated_src', project.idea.processors.outputDir
     assertEquals 'generated_testSrc', project.idea.processors.testOutputDir
   }
 
   @Test
-  public void addsEclipseConfigurationTasks_processorsFirst() {
+  void addsEclipseConfigurationTasks_processorsFirst() {
     Project project = ProjectBuilder.builder().build()
     project.pluginManager.apply 'org.inferred.processors'
     project.pluginManager.apply 'java'
@@ -45,7 +44,7 @@ class ProcessorsPluginTest {
   }
 
   @Test
-  public void addsEclipseConfigurationTasks_processorsLast() {
+  void addsEclipseConfigurationTasks_processorsLast() {
     Project project = ProjectBuilder.builder().build()
     project.pluginManager.apply 'java'
     project.pluginManager.apply 'eclipse'
@@ -56,7 +55,18 @@ class ProcessorsPluginTest {
   }
 
   @Test
-  public void configuresIdeaGeneratedSourcesDirectories() {
+  void addsEclipseConfigurationTasks_eclipseFirst() {
+    Project project = ProjectBuilder.builder().build()
+    project.pluginManager.apply 'org.inferred.processors'
+    project.pluginManager.apply 'eclipse'
+    project.pluginManager.apply 'java'
+
+    assertNotNull project.tasks.eclipseAptPrefs
+    assertNotNull project.tasks.eclipseFactoryPath
+  }
+
+  @Test
+  void configuresIdeaGeneratedSourcesDirectories() {
     Project project = ProjectBuilder.builder().build()
     project.pluginManager.apply 'org.inferred.processors'
     project.pluginManager.apply 'java'
@@ -69,17 +79,13 @@ class ProcessorsPluginTest {
   }
 
   @Test
-  public void addsEclipseConfigurationTasks_eclipseFirst() {
+  void configuredIdeaScopes() {
     Project project = ProjectBuilder.builder().build()
     project.pluginManager.apply 'org.inferred.processors'
-    project.pluginManager.apply 'eclipse'
     project.pluginManager.apply 'java'
+    project.pluginManager.apply 'idea'
 
-    assertNotNull project.tasks.eclipseAptPrefs
-    assertNotNull project.tasks.eclipseFactoryPath
-  }
-
-  private static JavaPluginConvention getJavaConvention(Project project) {
-    project.convention.plugins['java'] as JavaPluginConvention
+    assertFalse project.idea.module.scopes.PROVIDED.plus.contains(project.configurations['annotationProcessor'])
+    assertFalse project.idea.module.scopes.TEST.plus.contains(project.configurations['testAnnotationProcessor'])
   }
 }


### PR DESCRIPTION
## Before this PR
The IDEA plugin configures the `annotationProcessor` configuration as a `Provided` dependency and the `testAnnotationProcessor` configuration as a `Test` dependency (see https://github.com/gradle/gradle/pull/7067).

Unfortunately, `Provided` dependencies are included on the classpath when tests are run (see the chart in https://www.jetbrains.com/help/idea/dependencies.html#5672010c).

We have noticed that this behavior can cause `NoSuchMethodError` when running tests because it allows for multiple versions of the same jar to be on the classpath when running tests. We had both guava 28.0-jre as a `Compile` dependency (from our sources) _and_ guava 27.0.1-jre as a `Provided` dependency (from our annotation processor dependencies, specifically errorprone).

## After this PR
The processors plugin remove the annotation processor configurations from the IDEA module scopes. This prevent the type of conflicts described above.

## Possible downsides?
- After upgrading, users may need to add compile only dependencies if they were relying on dependencies from the annotation processor configuration to compile their code in Intellij.