### PR TITLE
Don't set up custom generated dirs if importing from intellij

### DIFF
--- a/changelog/@unreleased/pr-147.v2.yml
+++ b/changelog/@unreleased/pr-147.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Don't configure annotation processor directories when [importing from
+    IntelliJ](https://www.jetbrains.com/help/idea/gradle.html).
+  links:
+  - https://github.com/palantir/gradle-processors/pull/147

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -148,13 +148,18 @@ class ProcessorsPlugin implements Plugin<Project> {
     project.plugins.withType(IdeaPlugin, { plugin ->
       IdeaModel idea = project.extensions.getByType(IdeaModel)
       def extension = (idea as ExtensionAware).extensions.create('processors', IdeaProcessorsExtension)
-      extension.with {
-        outputDir = 'generated_src'
-        testOutputDir = 'generated_testSrc'
-      }
 
-      addGeneratedSourceFolder(project, { getIdeaSourceOutputDir(project) }, false)
-      addGeneratedSourceFolder(project, { getIdeaSourceTestOutputDir(project) }, true)
+      // Ensure we're not importing from intellij before configuring these, otherwise we will conflict with Intellij's
+      // own way of handling annotation processor output directories.
+      if (!Boolean.getBoolean("idea.active")) {
+        extension.with {
+          outputDir = 'generated_src'
+          testOutputDir = 'generated_testSrc'
+        }
+
+        addGeneratedSourceFolder(project, { getIdeaSourceOutputDir(project) }, false)
+        addGeneratedSourceFolder(project, { getIdeaSourceTestOutputDir(project) }, true)
+      }
 
       // We need to remove the configurations from the plus configurations.
       // If we instead added the configurations from the minus configurations, then that would remove dependencies that


### PR DESCRIPTION
## Before this PR

Importing a project in intellij 2019.3 ends up with duplicate "generated" source outputs:
* `generated_src` and `generated_testSrc` from this plugin
* `generated` and `generates_tests` from IntelliJ (sourced from here: https://github.com/JetBrains/intellij-community/blob/ee922d29c9f802708b7050d872dca0c62ddf43a1/jps/model-impl/src/org/jetbrains/jps/model/java/impl/compiler/ProcessorConfigProfileImpl.java#L130)

This then confuses intellij in "Build and run using: IntelliJ IDEA" mode, as it ends up writing annotation processor output to `generated_src/generated/`, which then doesn't get indexed properly because the file paths imply an extra `generated.` prefix to the package of the generated files.

It also causes IntelliJ to add both source and test "root paths" to each module. However, because IntelliJ import creates a separate module for each source set, this means that your `main` and `test` source sets both get a source AND a test root dir, causing errors.

## After this PR
==COMMIT_MSG==
Don't configure annotation processor directories when [importing from IntelliJ](https://www.jetbrains.com/help/idea/gradle.html).
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

