### PR TITLE
Fix nullpointer when running on projects that do not have the java plugin applied

### DIFF
--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -145,8 +145,8 @@ class ProcessorsPlugin implements Plugin<Project> {
   }
 
   private static void configureIdeaPlugin(Project project, Configuration allProcessorConf) {
-    project.plugins.withType(IdeaPlugin, { plugin ->
-        project.plugins.withType(JavaPlugin) {
+    project.plugins.withType(IdeaPlugin, { ideaPlugin ->
+        project.plugins.withType(JavaPlugin) { javaPlugin ->
             IdeaModel idea = project.extensions.getByType(IdeaModel)
             def extension = (idea as ExtensionAware).extensions.create('processors', IdeaProcessorsExtension)
 

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -2,6 +2,7 @@ package org.inferred.gradle
 
 import groovy.util.slurpersupport.NodeChild
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Test
 import spock.lang.Unroll
 
 class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
@@ -808,6 +809,22 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
     assertAutoValueInFile(file(".classpath"))
     assertAutoValueInFile(file(".factorypath"))
   }
+
+    @Test
+    void applying_to_project_with_idea_but_without_java_causes_no_errors() {
+        buildFile << """
+            apply plugin: 'org.inferred.processors'
+            apply plugin: 'idea'
+            
+            dependencies {
+            processor 'com.google.auto.value:auto-value:1.0'
+            }
+        """
+
+        expect:
+        runTasksSuccessfully('idea')
+
+    }
 
   private void assertAutoValueInFile(File file) {
     if (!file.any { it.contains("auto-value-1.0.jar") }) {

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -2,7 +2,6 @@ package org.inferred.gradle
 
 import groovy.util.slurpersupport.NodeChild
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.Test
 import spock.lang.Unroll
 
 class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
@@ -809,22 +808,6 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
     assertAutoValueInFile(file(".classpath"))
     assertAutoValueInFile(file(".factorypath"))
   }
-
-    @Test
-    void applying_to_project_with_idea_but_without_java_causes_no_errors() {
-        buildFile << """
-            apply plugin: 'org.inferred.processors'
-            apply plugin: 'idea'
-            
-            dependencies {
-            processor 'com.google.auto.value:auto-value:1.0'
-            }
-        """
-
-        expect:
-        runTasksSuccessfully('idea')
-
-    }
 
   private void assertAutoValueInFile(File file) {
     if (!file.any { it.contains("auto-value-1.0.jar") }) {

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
@@ -88,11 +88,4 @@ class ProcessorsPluginTest {
     assertFalse project.idea.module.scopes.PROVIDED.plus.contains(project.configurations['annotationProcessor'])
     assertFalse project.idea.module.scopes.TEST.plus.contains(project.configurations['testAnnotationProcessor'])
   }
-
-    @Test
-    void applying_to_project_without_java_causes_no_errors() {
-        Project project = ProjectBuilder.builder().build()
-        project.pluginManager.apply 'org.inferred.processors'
-        project.pluginManager.apply 'idea'
-    }
 }

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
@@ -88,4 +88,11 @@ class ProcessorsPluginTest {
     assertFalse project.idea.module.scopes.PROVIDED.plus.contains(project.configurations['annotationProcessor'])
     assertFalse project.idea.module.scopes.TEST.plus.contains(project.configurations['testAnnotationProcessor'])
   }
+
+    @Test
+    void applying_to_project_without_java_causes_no_errors() {
+        Project project = ProjectBuilder.builder().build()
+        project.pluginManager.apply 'org.inferred.processors'
+        project.pluginManager.apply 'idea'
+    }
 }


### PR DESCRIPTION
## Before this PR
If you apply this plugin before the `java` plugin, you get this error:

```
Caused by: java.lang.NullPointerException: Cannot invoke method get() on null object
        at org.inferred.gradle.ProcessorsPlugin$_configureIdeaPlugin_closure6.doCall(ProcessorsPlugin.groovy:163)
```

## After this PR
==COMMIT_MSG==
Fix `Cannot invoke method get() on null object` error when using the plugin on a project that does apply the java plugin.
==COMMIT_MSG==

