### PR TITLE
Revert "Remove annotation processor dependencies from IDEA scopes (#1…

### DIFF
--- a/changelog/@unreleased/pr-165.v2.yml
+++ b/changelog/@unreleased/pr-165.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Annotation processor dependencies are no longer explicitly removed
+    from IDEA scopes. As of Gradle 6.3, annotation processor dependencies are no longer
+    added to IDEA scopes by the IDEA plugin.
+  links:
+  - https://github.com/palantir/gradle-processors/pull/165

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -21,8 +21,6 @@ import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.gradle.plugins.ide.idea.model.IdeaModule
-import org.gradle.plugins.ide.idea.model.internal.GeneratedIdeaScope
-import org.gradle.plugins.ide.idea.model.internal.IdeaDependenciesProvider
 import org.gradle.util.GradleVersion
 
 class ProcessorsPlugin implements Plugin<Project> {
@@ -160,18 +158,6 @@ class ProcessorsPlugin implements Plugin<Project> {
         addGeneratedSourceFolder(project, { getIdeaSourceOutputDir(project) }, false)
         addGeneratedSourceFolder(project, { getIdeaSourceTestOutputDir(project) }, true)
       }
-
-      // We need to remove the configurations from the plus configurations.
-      // If we instead added the configurations from the minus configurations, then that would remove dependencies that
-      // are shared with other configurations in the plus configurations.
-      idea.module.scopes
-              .get(GeneratedIdeaScope.PROVIDED.name())
-              .get(IdeaDependenciesProvider.SCOPE_PLUS)
-              .remove(JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME)
-      idea.module.scopes
-              .get(GeneratedIdeaScope.TEST.name())
-              .get(IdeaDependenciesProvider.SCOPE_PLUS)
-              .remove(JavaPlugin.TEST_ANNOTATION_PROCESSOR_CONFIGURATION_NAME)
 
       // Root project configuration
       def rootModel = project.rootProject.extensions.findByType(IdeaModel)

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginTest.groovy
@@ -77,15 +77,4 @@ class ProcessorsPluginTest {
     assertTrue project.idea.module.testSourceDirs.contains(project.file('generated_testSrc'))
     assertTrue project.idea.module.generatedSourceDirs.contains(project.file('generated_testSrc'))
   }
-
-  @Test
-  void configuredIdeaScopes() {
-    Project project = ProjectBuilder.builder().build()
-    project.pluginManager.apply 'org.inferred.processors'
-    project.pluginManager.apply 'java'
-    project.pluginManager.apply 'idea'
-
-    assertFalse project.idea.module.scopes.PROVIDED.plus.contains(project.configurations['annotationProcessor'])
-    assertFalse project.idea.module.scopes.TEST.plus.contains(project.configurations['testAnnotationProcessor'])
-  }
 }


### PR DESCRIPTION
This reverts #144.

## Before this PR
#144 never quite worked as intended because the order in which the actions are applied when using `withType` is not guaranteed. This change here only worked if it was applied after this action from the IDEA plugin:
https://github.com/gradle/gradle/blob/v6.2.2/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java#L327-L332

## After this PR
The underlying issue has been fixed in Gradle in https://github.com/gradle/gradle/pull/12353. Thus this workaround is no longer necessary. 

