### PR TITLE
Remove extra log spam

### DIFF
--- a/changelog/@unreleased/pr-207.v2.yml
+++ b/changelog/@unreleased/pr-207.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Remove extra log spam
+  links:
+  - https://github.com/palantir/gradle-processors/pull/207

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -265,7 +265,6 @@ class ProcessorsPlugin implements Plugin<Project> {
                 .replaceAll('^\\Qfile://$PROJECT_DIR$/', '')
         def outputDir = dependencyModule.outputDir
                 ?: project.rootProject.file("${projectOutputDir}/production/${dependencyModule.name}")
-        log.lifecycle("Configuring annotation dependency ${project.path} -> ${dependencyProject.path} with output dir: $outputDir")
         return outputDir
       } else {
         return artifact.file


### PR DESCRIPTION
Services that consume and process their own 'annotation dependencies' (there's an AtlasDB annotation processor, but this appears to happen for anyone who adds their own ErrorProne checks as well) get this logged out each time they use the thing. IIRC from talking to DanS, this was just a logline to debug that something was actually happening.