### PR TITLE
The processors configuration uses runtime components

### DIFF
--- a/changelog/@unreleased/pr-211.v2.yml
+++ b/changelog/@unreleased/pr-211.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: The processors configuration uses the `JAVA_RUNTIME` attribute rather
+    than `JAVA_API`, allowing transitive `implementation` and `runtimeOnly` annotation-processor
+    dependencies to be discovered correctly by IDEs.
+  links:
+  - https://github.com/palantir/gradle-processors/pull/211

--- a/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
+++ b/src/main/groovy/org/inferred/gradle/ProcessorsPlugin.groovy
@@ -49,7 +49,7 @@ class ProcessorsPlugin implements Plugin<Project> {
       // to require rebuilding the jar every time. This ensures that when resolving, we get the "classes" variant out
       // of such projects, if it is defined.
       attributes {
-        attribute Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_API)
+        attribute Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME)
       }
     }
 


### PR DESCRIPTION
This allows `implementation` dependencies to work as expected.

==COMMIT_MSG==
The processors configuration uses runtime components
==COMMIT_MSG==
