### PR TITLE
fix eclipse annotation processing

### DIFF
--- a/changelog/@unreleased/pr-241.v2.yml
+++ b/changelog/@unreleased/pr-241.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: fix eclipse annotation processing
+  links:
+  - https://github.com/palantir/gradle-processors/pull/241

--- a/src/main/resources/org/inferred/gradle/apt-prefs.template
+++ b/src/main/resources/org/inferred/gradle/apt-prefs.template
@@ -2,6 +2,7 @@ eclipse.preferences.version=1
 <% if (!deps.empty) { %>\
 org.eclipse.jdt.apt.aptEnabled=true
 org.eclipse.jdt.apt.genSrcDir=${outputDir}
+org.eclipse.jdt.apt.genTestSrcDir=${testOutputDir}
 org.eclipse.jdt.apt.reconcileEnabled=true
 <% } else { %>\
 org.eclipse.jdt.apt.aptEnabled=false

--- a/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/inferred/gradle/ProcessorsPluginFunctionalTest.groovy
@@ -375,7 +375,8 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
     def expected = """
       eclipse.preferences.version=1
       org.eclipse.jdt.apt.aptEnabled=true
-      org.eclipse.jdt.apt.genSrcDir=generated${File.separator}java
+      org.eclipse.jdt.apt.genSrcDir=generated_src
+      org.eclipse.jdt.apt.genTestSrcDir=generated_testSrc
       org.eclipse.jdt.apt.reconcileEnabled=true
     """.replaceFirst('\n','').stripIndent()
 
@@ -395,6 +396,7 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
 
       eclipse.processors {
         outputDir = 'something'
+        testOutputDir = 'testsomething'
       }
     """
 
@@ -415,6 +417,7 @@ class ProcessorsPluginFunctionalTest extends AbstractPluginTest {
       eclipse.preferences.version=1
       org.eclipse.jdt.apt.aptEnabled=true
       org.eclipse.jdt.apt.genSrcDir=something
+      org.eclipse.jdt.apt.genTestSrcDir=testsomething
       org.eclipse.jdt.apt.reconcileEnabled=true
     """.replaceFirst('\n', '').stripIndent()
 


### PR DESCRIPTION
Hook up test annotation processing. Use the same output directories as
idea.

## Before this PR
Eclipse annotation processing didn't work.

## After this PR
==COMMIT_MSG==
fix eclipse annotation processing
==COMMIT_MSG==

## Possible downsides?
None.
